### PR TITLE
Update JQueryResourceReference

### DIFF
--- a/src/main/java/de/agilecoders/wicket/markup/html/references/BootstrapJavaScriptReference.java
+++ b/src/main/java/de/agilecoders/wicket/markup/html/references/BootstrapJavaScriptReference.java
@@ -1,6 +1,7 @@
 package de.agilecoders.wicket.markup.html.references;
 
 import com.google.common.collect.Lists;
+import org.apache.wicket.Application;
 import org.apache.wicket.markup.head.HeaderItem;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.request.resource.JavaScriptResourceReference;
@@ -33,7 +34,7 @@ public class BootstrapJavaScriptReference extends JavaScriptResourceReference {
     @Override
     public Iterable<? extends HeaderItem> getDependencies() {
         List<HeaderItem> dependencies = Lists.newArrayList(super.getDependencies());
-        dependencies.add(JavaScriptHeaderItem.forReference(JQueryResourceReference.get()));
+        dependencies.add(JavaScriptHeaderItem.forReference(Application.get().getJavaScriptLibrarySettings().getJQueryReference()));
 
         return dependencies;
     }

--- a/src/main/java/de/agilecoders/wicket/markup/html/references/JqueryPPJavaScriptReference.java
+++ b/src/main/java/de/agilecoders/wicket/markup/html/references/JqueryPPJavaScriptReference.java
@@ -1,6 +1,7 @@
 package de.agilecoders.wicket.markup.html.references;
 
 import com.google.common.collect.Lists;
+import org.apache.wicket.Application;
 import org.apache.wicket.markup.head.HeaderItem;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.request.resource.JavaScriptResourceReference;
@@ -33,7 +34,7 @@ public class JqueryPPJavaScriptReference extends JavaScriptResourceReference {
     @Override
     public Iterable<? extends HeaderItem> getDependencies() {
         List<HeaderItem> dependencies = Lists.newArrayList(super.getDependencies());
-        dependencies.add(JavaScriptHeaderItem.forReference(JQueryResourceReference.get()));
+        dependencies.add(JavaScriptHeaderItem.forReference(Application.get().getJavaScriptLibrarySettings().getJQueryReference()));
 
         return dependencies;
     }


### PR DESCRIPTION
In wicket 6.0.0, you can configure the JQueryResourceReference which should be used by setting the corresponding Resource in IJavaScriptLibrarySettings.

Consequently, every dependency to jquery should use this configured resource (and not the fallback JQueryResourceReference directly).

I just updated both occurences in your code to pay attention to this.
