### PR TITLE
Removing duplicate css type for forms

### DIFF
--- a/src/main/java/de/agilecoders/wicket/markup/html/bootstrap/form/BootstrapForm.java
+++ b/src/main/java/de/agilecoders/wicket/markup/html/bootstrap/form/BootstrapForm.java
@@ -1,7 +1,5 @@
 package de.agilecoders.wicket.markup.html.bootstrap.form;
 
-import de.agilecoders.wicket.markup.html.bootstrap.behavior.CssClassNameAppender;
-import de.agilecoders.wicket.markup.html.bootstrap.behavior.CssClassNameProvider;
 import org.apache.wicket.model.IModel;
 
 /**
@@ -12,33 +10,7 @@ import org.apache.wicket.model.IModel;
  */
 public class BootstrapForm<T> extends org.apache.wicket.markup.html.form.Form<T> {
 
-    private Type type;
-
-    /**
-     * TODO document
-     */
-    public enum Type implements CssClassNameProvider {
-        Vertical("form-vertical"), // Stacked, left-aligned labels over controls
-        Inline("form-inline"), // Left-aligned label and inline-block controls for compact style
-        Search("form-search"), // Extra-rounded text input for a typical search aesthetic
-        Horizontal("form-horizontal"); // (default) Float left, right-aligned labels on same line as controls
-
-        private final String cssClassName;
-
-        Type(String cssClassName) {
-            this.cssClassName = cssClassName;
-        }
-
-        @Override
-        public String cssClassName() {
-            return cssClassName;
-        }
-
-        @Override
-        public CssClassNameAppender newCssClassNameAppender() {
-            return new CssClassNameAppender(this);
-        }
-    }
+    private FormBehavior formBehavior;
 
     /**
      * Constructs a from with no validation
@@ -66,19 +38,11 @@ public class BootstrapForm<T> extends org.apache.wicket.markup.html.form.Form<T>
      * Common code executed by constructors.
      */
     private void commonInit() {
-        type = Type.Horizontal;
+        add(formBehavior = new FormBehavior());
     }
     
-    public BootstrapForm<T> type(Type type) {
-        this.type = type;
-
+    public BootstrapForm<T> type(FormType type) {
+        formBehavior.type(type);
         return this;
-    }
-
-    @Override
-    protected void onConfigure() {
-        super.onConfigure();
-        
-        add(type.newCssClassNameAppender());
     }
 }

--- a/src/main/java/de/agilecoders/wicket/markup/html/bootstrap/form/FormBehavior.java
+++ b/src/main/java/de/agilecoders/wicket/markup/html/bootstrap/form/FormBehavior.java
@@ -1,8 +1,6 @@
 package de.agilecoders.wicket.markup.html.bootstrap.form;
 
 import de.agilecoders.wicket.markup.html.bootstrap.behavior.BootstrapBaseBehavior;
-import de.agilecoders.wicket.markup.html.bootstrap.behavior.CssClassNameAppender;
-import de.agilecoders.wicket.markup.html.bootstrap.behavior.CssClassNameProvider;
 import org.apache.wicket.Component;
 
 /**
@@ -13,32 +11,17 @@ import org.apache.wicket.Component;
  */
 public class FormBehavior extends BootstrapBaseBehavior {
 
-    public enum Type implements CssClassNameProvider {
-        Default, Vertical, Inline, Search, Horizontal;
-
-        @Override
-        public String cssClassName() {
-            return equals(Default) ? "" : "form-" + name().toLowerCase();
-        }
-
-        @Override
-        public CssClassNameAppender newCssClassNameAppender() {
-            return new CssClassNameAppender(cssClassName());
-        }
-
-    }
-
-    private Type type;
+    private FormType type;
 
     public FormBehavior() {
-        this(Type.Default);
+        this(FormType.Default);
     }
 
-    public FormBehavior(Type type) {
+    public FormBehavior(FormType type) {
         this.type = type;
     }
 
-    public FormBehavior type(Type type) {
+    public FormBehavior type(FormType type) {
         this.type = type;
         return this;
     }

--- a/src/main/java/de/agilecoders/wicket/markup/html/bootstrap/form/FormType.java
+++ b/src/main/java/de/agilecoders/wicket/markup/html/bootstrap/form/FormType.java
@@ -1,0 +1,30 @@
+package de.agilecoders.wicket.markup.html.bootstrap.form;
+
+import de.agilecoders.wicket.markup.html.bootstrap.behavior.CssClassNameAppender;
+import de.agilecoders.wicket.markup.html.bootstrap.behavior.CssClassNameProvider;
+
+/**
+ * TODO document
+ */
+public enum FormType implements CssClassNameProvider {
+    Default(""), // Stacked, left-aligned labels on top of form controls
+    Inline("form-inline"), // Left-aligned label and inline-block controls for compact style
+    Search("form-search"), // Extra-rounded text input for a typical search aesthetic
+    Horizontal("form-horizontal"); // (default) Float left, right-aligned labels on same line as controls
+
+    private final String cssClassName;
+
+    private FormType(String cssClassName) {
+        this.cssClassName = cssClassName;
+    }
+
+    @Override
+    public String cssClassName() {
+        return cssClassName;
+    }
+
+    @Override
+    public CssClassNameAppender newCssClassNameAppender() {
+        return new CssClassNameAppender(this);
+    }
+}


### PR DESCRIPTION
I refactored the duplicated css type (one in BootstrapForm, one in FormBehavior) to only one type.

At the same time, i deleted the "form-vertical" as there is no such type in bootstrap (according to bootstrap doc, this is the "default" type when not using one of the optional form-xyz classes).
So, the new enum contains Default, Inline, Search and Horizontal.

In compliance with bootstraps default form class (i.e. no special optional class) i also changed the BootstrapForm's default type to "default" (from horizontal as before).

As a remark, BootstrapForm now does not serve some special behaviour anymore (beside the "type" function) and could be deleted/deprecated by just using one of wickets standard form classes and just adding the desired FormBehavior.
