### PR TITLE
Remove dependency from less to core.

### DIFF
--- a/bootstrap-less/pom.xml
+++ b/bootstrap-less/pom.xml
@@ -27,8 +27,8 @@
         </dependency>
 
         <dependency>
-            <groupId>de.agilecoders.wicket</groupId>
-            <artifactId>wicket-bootstrap-core</artifactId>
+            <groupId>org.apache.wicket</groupId>
+            <artifactId>wicket-core</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/bootstrap-less/src/main/java/de/agilecoders/wicket/less/LessJsLessCompiler.java
+++ b/bootstrap-less/src/main/java/de/agilecoders/wicket/less/LessJsLessCompiler.java
@@ -3,7 +3,6 @@ package de.agilecoders.wicket.less;
 import com.asual.lesscss.LessEngine;
 import com.asual.lesscss.LessException;
 import com.asual.lesscss.LessOptions;
-import de.agilecoders.wicket.util.Generics2;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.util.lang.Exceptions;
 import org.apache.wicket.util.string.Strings;
@@ -75,7 +74,7 @@ public class LessJsLessCompiler extends AbstractLessCompiler {
 
         String extract = null;
         if (extractList != null) {
-            extract = Generics2.join(extractList, ',');
+            extract = Strings.join(",", extractList);
         }
 
         // Try to detect missing imports

--- a/bootstrap-less/src/test/java/de/agilecoders/wicket/less/Less4JCompilerTest.java
+++ b/bootstrap-less/src/test/java/de/agilecoders/wicket/less/Less4JCompilerTest.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
-import static de.agilecoders.wicket.util.Strings2.nullToEmpty;
-
 /**
  * Tests the {@link Less4JCompiler} class
  *
@@ -140,8 +138,11 @@ public class Less4JCompilerTest {
      * @param value The value to clean
      * @return cleaned value
      */
-    private String removeLineBreaks(String value) {
-        return nullToEmpty(value).replaceAll("\n", "").replaceAll("  ", " ");
+    private static String removeLineBreaks(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("\n", "").replaceAll("  ", " ");
     }
 
 }


### PR DESCRIPTION
Removed dependencies on a couple of utility functions in `wicket-bootstrap-core`. 

`wicket-bootstrap-less` seems like a sufficiently generic solution for `*.less` resource management in wicket so shouldn't depend on bootstrap, no?
