### PR TITLE
include junit in test scope only

### DIFF
--- a/bootstrap-common-tests/pom.xml
+++ b/bootstrap-common-tests/pom.xml
@@ -57,6 +57,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+      <scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/bootstrap-core/pom.xml
+++ b/bootstrap-core/pom.xml
@@ -86,6 +86,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- HAMCREST DEPENDENCIES -->

--- a/bootstrap-extensions/pom.xml
+++ b/bootstrap-extensions/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- HAMCREST DEPENDENCIES -->

--- a/bootstrap-less/pom.xml
+++ b/bootstrap-less/pom.xml
@@ -31,6 +31,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+      <scope>test</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
As the title says: junit doesn't seem to be used in runtime scope and can be set to test scope.
