### PR TITLE
Improved initializer script for in CodeBehavior.

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/block/CodeBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/block/CodeBehavior.java
@@ -93,7 +93,11 @@ public class CodeBehavior extends Behavior {
 
         References.renderWithFilter(Bootstrap.getSettings(), response, JavaScriptHeaderItem.forReference(BootstrapPrettifyJavaScriptReference.INSTANCE));
 
-        response.render(OnDomReadyHeaderItem.forScript("window.prettyPrint && prettyPrint();"));
+        response.render(OnDomReadyHeaderItem.forScript(createInitializerScript(component.getMarkupId(true))));
+    }
+
+    private CharSequence createInitializerScript(String markupId) {
+        return "$('#" + markupId + "').html(prettyPrintOne($('#" + markupId + "').html().replace(/\\r\\n|\\r|\\n/g,'<br>'), '', $('#" + markupId + "').attr('class')));";
     }
 
     @Override


### PR DESCRIPTION
The current implementation works fine when page loads but when i add new elements dynamically it doesn't work!

Example:
If I switch Tabs in an AjaxTabbedPanel with prettified panels - the other AjaxTabbedPanel will rerender the linenumbers. See screenshot.

Solution:
Initialize with prettyPrintOne() instead of prettyPrint();
![prettyprint](https://f.cloud.github.com/assets/1846056/1201017/b121f950-252e-11e3-95b1-8892a1a7b356.png)
