### PR TITLE
Update bootstrap.wicket.css

### DIFF
--- a/bootstrap-themes/src/main/java/de/agilecoders/wicket/themes/markup/html/wicket/css/bootstrap.wicket.css
+++ b/bootstrap-themes/src/main/java/de/agilecoders/wicket/themes/markup/html/wicket/css/bootstrap.wicket.css
@@ -1,4 +1,5 @@
 @import url(https://fonts.googleapis.com/css?family=Ubuntu);
+.media-object {display: block; padding-right: 10px; padding-right: 10px;}
 article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block;}
 section { background-color:#FFF; -webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;padding: 10px; padding-top: 2px; margin-top: 30px;}
 audio,canvas,video{display:inline-block;*display:inline;*zoom:1;}


### PR DESCRIPTION
Added right/left padding of 10px to the media-object class for the wicket theme.

This handles the text butting right up against the image as shown in the live demo:
http://wb.agilecoders.de/demo/components?theme=wicket#media

See wicket-bootstrap Issue #229 at:
https://github.com/l0rdn1kk0n/wicket-bootstrap/issues/229 
