### PR TITLE
Removed default breadcrumb separator since bootstrap adds its own via CSS

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/Breadcrumb.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/Breadcrumb.java
@@ -37,4 +37,15 @@ public class Breadcrumb extends BreadCrumbBar {
         checkComponentTag(tag, "ul");
         Attributes.addClass(tag, "breadcrumb");
     }
+    
+	/**
+	 * Overrides the method in the super class to remove the default / separator since twitter-bootstrap adds the separators via CSS.
+	 * 
+	 * @see org.apache.wicket.extensions.breadcrumb.BreadCrumbBar#getSeparatorMarkup()
+	 */
+	@Override
+	protected String getSeparatorMarkup() {
+
+		return "";
+	}
 }


### PR DESCRIPTION
I think Breadcrumb should override getSeparatorMarkup() to remove the default "/" separator for breadcrumb items because bootstrap adds its own via CSS.
