### PR TITLE
Bootstrap 3 : Using Bootstrap3 event name for Modal

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/Modal.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/Modal.java
@@ -76,7 +76,7 @@ public class Modal extends Panel {
             }
         });
 
-        closeBehavior = new AjaxEventBehavior("hidden") {
+        closeBehavior = new AjaxEventBehavior("hidden.bs.modal") {
             @Override
             protected void onEvent(final AjaxRequestTarget target) {
                 handleCloseEvent(target);


### PR DESCRIPTION
Modal events have changed name in Bootstrap 3 : 
http://getbootstrap.com/javascript/#modals-usage
