### PR TITLE
avoid css effects for link tag

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/dropdown/MenuDivider.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/dropdown/MenuDivider.java
@@ -21,6 +21,7 @@ public class MenuDivider extends AbstractLink {
 
         setBody(Model.of("&nbsp;"));
         setEscapeModelStrings(false);
+        setRenderBodyOnly(true);
     }
 
     @Override


### PR DESCRIPTION
Because it extends AbstractLink the body will be wrapped in a link tag which results in changing his color on 'hover'.

So rendering only it's body fixes the issue.
