### PR TITLE
Bootstrap3 : DateTextField - start/end date should use the date time in ISO8601 format

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/DateTextFieldConfig.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/DateTextFieldConfig.java
@@ -14,9 +14,6 @@ import org.joda.time.format.DateTimeFormatter;
  * @author miha
  */
 public class DateTextFieldConfig extends AbstractConfig {
-
-    private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("dd/MM/yyyy");
-
     /**
      * The earliest date that may be selected; all earlier dates will be disabled.
      */
@@ -133,7 +130,7 @@ public class DateTextFieldConfig extends AbstractConfig {
      * @return this instance for chaining
      */
     public DateTextFieldConfig withStartDate(final DateTime value) {
-        put(StartDate, value.toString(FORMATTER));
+        put(StartDate, value.toString());
         return this;
     }
 
@@ -144,7 +141,7 @@ public class DateTextFieldConfig extends AbstractConfig {
      * @return this instance for chaining
      */
     public DateTextFieldConfig withEndDate(final DateTime value) {
-        put(EndDate, value.toString(FORMATTER));
+        put(EndDate, value.toString());
         return this;
     }
 


### PR DESCRIPTION
When using DateTextField with a custom format, withFormat("yyyy-mm-dd") for example, then using withStartDate and withEndDate do not work properly.

In the code withStartDate and withEndDate allways use the same Formatter :

``` java
    public DateTextFieldConfig withStartDate(final DateTime value) {
        put(StartDate, value.toString(FORMATTER));
        return this;
    }
```

Instead start/end date should use the date time in ISO8601 format (yyyy-MM-ddTHH:mm:ss.SSSZZ).
