### PR TITLE
NPE in UpdatableProgressBar.commonInit()

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/UpdatableProgressBar.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/UpdatableProgressBar.java
@@ -18,14 +18,10 @@ public abstract class UpdatableProgressBar extends ProgressBar {
 
     public UpdatableProgressBar(String id) {
         super(id);
-
-        commonInit();
     }
 
     public UpdatableProgressBar(String id, IModel<Integer> model) {
         super(id, model);
-
-        commonInit();
     }
 
     public Duration updateInterval() {
@@ -37,7 +33,10 @@ public abstract class UpdatableProgressBar extends ProgressBar {
         return this;
     }
 
-    private void commonInit() {
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+
         setOutputMarkupId(true);
         active(true);
         striped(true);

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/UpdatableProgressBarTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/UpdatableProgressBarTest.java
@@ -1,0 +1,27 @@
+package de.agilecoders.wicket.core.markup.html.bootstrap.components;
+
+import de.agilecoders.wicket.core.WicketApplicationTest;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.junit.Test;
+
+/**
+ * @author sschrader, t8y.com
+ */
+public class UpdatableProgressBarTest extends WicketApplicationTest {
+
+    @Test
+    public void progressInitialized() {
+        UpdatableProgressBar progressBar = new UpdatableProgressBar(id()) {
+            @Override
+            protected IModel<Integer> newValue() {
+                return Model.of(Integer.valueOf((int) (Math.random() * 100)));
+            }
+        };
+
+        startComponentInPage(progressBar);
+
+        tester().assertUsability(progressBar);
+    }
+
+}


### PR DESCRIPTION
The UpdatableProgressBar retrieves the indicator component which is not initialized or added at this point. I simply renamed `UpdatableProgressBar.commonInt()` to `UpdatableProgressBar.onInitialize()`.
