### PR TITLE
Removed active css class for tabs

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/Collapsible.html
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/Collapsible.html
@@ -10,7 +10,7 @@
                         <a wicket:id="title" class="accordion-toggle" data-toggle="collapse">Title</a>
                     </h3>
                 </div>
-                <div wicket:id="body" class="panel-collapse collapse in">
+                <div wicket:id="body" class="panel-collapse collapse">
                     <div class="panel-body">
                         <div wicket:id="content">Content</div>
                     </div>


### PR DESCRIPTION
The Collapsible is always open because of the static "in" css class in the corresponding html file
