### PR TITLE
Infinitescroll evaluating response with javascript

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/InfiniteScrollingBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/InfiniteScrollingBehavior.java
@@ -22,6 +22,7 @@ import java.util.Map;
  * @link http://www.infinite-scroll.com/
  */
 public class InfiniteScrollingBehavior extends Behavior {
+    private static final ResourceReference WICKET_ADAPTER = new JQueryPluginResourceReference(InfiniteScrollingBehavior.class, "js/infinitescroll-wicket-adapter.js");
     private static final ResourceReference JS = new JQueryPluginResourceReference(InfiniteScrollingBehavior.class, "js/jquery.infinitescroll.js");
 
     private boolean autoScroll = true;
@@ -37,6 +38,7 @@ public class InfiniteScrollingBehavior extends Behavior {
     public void renderHead(Component component, IHeaderResponse headerResponse) {
         super.renderHead(component, headerResponse);
 
+        headerResponse.render(JavaScriptHeaderItem.forReference(WICKET_ADAPTER));
         headerResponse.render(JavaScriptHeaderItem.forReference(JS));
         headerResponse.render(OnDomReadyHeaderItem.forScript(createScript(component)));
     }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/js/infinitescroll-wicket-adapter.js
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/js/infinitescroll-wicket-adapter.js
@@ -1,0 +1,93 @@
+/*
+ * simulates Wicket.Ajax.process(data)
+ */
+
+;
+(function () {
+
+  'use strict';
+
+  if (typeof(WicketInfinitescrollAdapter) !== 'undefined') {
+    return;
+  }
+
+  // plain copy from wicket-ajax-jquery.js
+  var FunctionsExecuter = function (functions) {
+
+    this.functions = functions;
+
+    this.current = 0;
+
+    this.depth = 0; // we need to limit call stack depth
+
+    this.processNext = function () {
+      if (this.current < this.functions.length) {
+        var f, run;
+
+        f = this.functions[this.current];
+        run = function () {
+          try {
+            var n = jQuery.proxy(this.notify, this);
+            f(n);
+          }
+          catch (e) {
+            Wicket.Log.error("FunctionsExecuter.processNext: " + e);
+          }
+        };
+        run = jQuery.proxy(run, this);
+        this.current++;
+
+        if (this.depth > 1000) {
+          // to prevent stack overflow (see WICKET-4675)
+          this.depth = 0;
+          window.setTimeout(run, 1);
+        }
+        else {
+          this.depth++;
+          run();
+        }
+      }
+    };
+
+    this.start = function () {
+      this.processNext();
+    };
+
+    this.notify = function () {
+      this.processNext();
+    };
+  };
+
+  /**
+   * Simulates a call like Wicket.Ajax.process(data), but without parsing data to a XMLDocument.
+   *
+   * You should remove any children from the <ajax-response> element inside data,
+   * which already has been processed by the infinitescroll extension.
+   * Otherwise Wicket will replace the existing components instead of appending them to your container.
+   */
+  // modified copy from wicket-ajax-jquery.js
+  var process = function (data) {
+    var context = {
+      attrs: {},
+      steps: []
+    };
+    var call = new Wicket.Ajax.Call();
+    call.loadedCallback(data, context);
+    var executer = new FunctionsExecuter(context.steps);
+    executer.start();
+  };
+
+  window.WicketInfinitescrollAdapter = function (ajaxResponse, componentToBeIgnored) {
+    ajaxResponse.removeChild(componentToBeIgnored);
+
+    var ajaxResponseToBeProcessedByWicket;
+    ajaxResponseToBeProcessedByWicket = document.implementation.createDocument(null, null);
+    ajaxResponseToBeProcessedByWicket.appendChild(ajaxResponse);
+
+    return {
+      processInfiniteScrollResponse: function () {
+        process(ajaxResponseToBeProcessedByWicket);
+      }
+    }
+  };
+})();

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/js/jquery.infinitescroll.js
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navigation/js/jquery.infinitescroll.js
@@ -396,6 +396,11 @@
               $(opts.contentSelector).append(frag);
           }
 
+
+          // https://github.com/l0rdn1kk0n/wicket-bootstrap/issues/363
+          var ajaxResponse = data.getElementsByTagName('ajax-response')[0];
+          WicketInfinitescrollAdapter(ajaxResponse, com[0]).processInfiniteScrollResponse();
+
           // previously, we would pass in the new DOM element as context for the callback
           // however we're now using a documentfragment, which doesn't have parents or children,
           // so the context is the contentContainer guy, and we pass in an array

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/panels/pagination/AbstractPaginationPanel.java
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/panels/pagination/AbstractPaginationPanel.java
@@ -1,10 +1,12 @@
 package de.agilecoders.wicket.samples.panels.pagination;
 
+import de.agilecoders.wicket.core.markup.html.bootstrap.components.PopoverBehavior;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.PageableListView;
 import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.Model;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +26,7 @@ public abstract class AbstractPaginationPanel extends Panel {
         pageable = new PageableListView<String>("pageable", data, pageSize()) {
             @Override
             protected void populateItem(ListItem<String> item) {
-                item.add(new Label("item", item.getModelObject()));
+                onPopulateItem(item);
             }
         };
         add(pageable);
@@ -34,6 +36,11 @@ public abstract class AbstractPaginationPanel extends Panel {
 
     protected List<String> createData() {
         return Arrays.asList("Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6");
+    }
+
+    protected void onPopulateItem(ListItem<String> item) {
+        item.add(new Label("item", item.getModelObject())
+                     .add(new PopoverBehavior(Model.of("popover" + item.getModelObject()), Model.of("body"))));
     }
 
     protected int pageSize() {


### PR DESCRIPTION
Infinitescroll wasn't aware of Wicket specific ajax-response processing. This PR adds a slightly modified Wicket.Ajax.process(data) call to the append handler of subsequent page requests.

fixes #363
