### PR TITLE
Patched ToolTip to respect IComponentAssignedModel

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehavior.java
@@ -2,12 +2,15 @@ package de.agilecoders.wicket.core.markup.html.bootstrap.components;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.BootstrapJavascriptBehavior;
 import de.agilecoders.wicket.jquery.AbstractConfig;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.apache.wicket.model.IComponentAssignedModel;
 import org.apache.wicket.model.IModel;
 
+import static com.google.common.base.Preconditions.*;
 import static de.agilecoders.wicket.jquery.JQuery.$;
 
 /**
@@ -20,6 +23,7 @@ public class TooltipBehavior extends BootstrapJavascriptBehavior {
 
     private final IModel<String> label;
     private final TooltipConfig config;
+    private IModel<String> labelResolved;
 
     /**
      * Construct.
@@ -53,16 +57,22 @@ public class TooltipBehavior extends BootstrapJavascriptBehavior {
         super.onComponentTag(component, tag);
 
         tag.put("rel", createRelAttribute());
-        tag.put("title", label.getObject());
+        tag.put("title", labelResolved.getObject());
     }
 
     @Override
     public void bind(final Component component) {
         super.bind(component);
-
+        labelResolved=wrapOnAssignment(label, component);
         component.setOutputMarkupId(true);
     }
-
+    private IModel<String> wrapOnAssignment(IModel<String> label, Component component) {
+        if (label != null && label instanceof IComponentAssignedModel) {
+            IComponentAssignedModel<String> cam = (IComponentAssignedModel<String>) label;
+            return cam.wrapOnAssignment(checkNotNull(component));
+        }
+        return label;
+    }
     /**
      * @return the value of the "rel" attribute
      */

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/MyContainer.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/MyContainer.java
@@ -1,0 +1,13 @@
+package de.agilecoders.wicket.core.markup.html.bootstrap.components;
+
+import org.apache.wicket.markup.html.WebMarkupContainer;
+
+public class MyContainer extends WebMarkupContainer{
+
+    public MyContainer(String id) {
+        super(id);
+    }
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/MyContainer.properties
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/MyContainer.properties
@@ -1,0 +1,1 @@
+label=bar

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehaviorTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehaviorTest.java
@@ -1,9 +1,11 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.components;
 
 import de.agilecoders.wicket.core.WicketApplicationTest;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.util.tester.TagTester;
 import org.junit.Test;
 
@@ -40,6 +42,13 @@ public class TooltipBehaviorTest extends WicketApplicationTest {
 
         tester().assertNoErrorMessage();
         tester().assertVisible(id());
+    }
+    
+    @Test
+    public void labelIsLocalized() {
+        tester().startComponentInPage(new MyContainer(id()).add(new TooltipBehavior(new ResourceModel("label"))));
+        final TagTester tag = tester().getTagByWicketId(id());
+        assertThat(tag.getAttribute("title"), is(equalTo("bar")));
     }
 
     /**


### PR DESCRIPTION
using ToolTip with ResourceModels failed, due to those not being assigned to the component.
I created a naive patch for this, but probably, you want to pull that to a common place and use it in different behaviors?
