### PR TITLE
added configuration option for the defer script attribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.java]
+indent_style = space
+indent_size = 4

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/behavior/BootstrapJavascriptBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/behavior/BootstrapJavascriptBehavior.java
@@ -30,7 +30,7 @@ public class BootstrapJavascriptBehavior extends BootstrapBaseBehavior {
     public void renderHead(IBootstrapSettings settings, IHeaderResponse headerResponse) {
         super.renderHead(settings, headerResponse);
 
-        final JavaScriptReferenceHeaderItem jsReference = JavaScriptHeaderItem.forReference(settings.getJsResourceReference(), new PageParameters(), "bootstrap-js", true);
+        final JavaScriptReferenceHeaderItem jsReference = JavaScriptHeaderItem.forReference(settings.getJsResourceReference(), new PageParameters(), "bootstrap-js", settings.deferJavascript());
         References.renderWithFilter(settings, headerResponse, jsReference);
     }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/settings/BootstrapSettings.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/settings/BootstrapSettings.java
@@ -34,6 +34,8 @@ public class BootstrapSettings implements IBootstrapSettings {
     private boolean updateSecurityManager;
     private boolean autoAppendResources;
     private boolean useCdnResources;
+
+    private boolean deferJavascript;
     private String version = VERSION;
     private String modernizrVersion = MODERNIZR_VERSION;
 
@@ -47,6 +49,7 @@ public class BootstrapSettings implements IBootstrapSettings {
         this.updateSecurityManager = true;
         this.autoAppendResources = true;
         this.useCdnResources = false;
+        this.deferJavascript = true;
     }
 
     @Override
@@ -64,6 +67,11 @@ public class BootstrapSettings implements IBootstrapSettings {
     @Override
     public String getVersion() {
         return version;
+    }
+
+    @Override
+    public boolean deferJavascript() {
+        return deferJavascript;
     }
 
     @Override
@@ -171,6 +179,12 @@ public class BootstrapSettings implements IBootstrapSettings {
     }
 
     @Override
+    public IBootstrapSettings setDeferJavascript(boolean defer) {
+        deferJavascript = defer;
+        return this;
+    }
+
+    @Override
     public BootstrapSettings setActiveThemeProvider(ActiveThemeProvider activeThemeProvider) {
         this.activeThemeProvider = activeThemeProvider;
         return this;
@@ -190,7 +204,7 @@ public class BootstrapSettings implements IBootstrapSettings {
     @Override
     public final boolean useWebjars() {
         return !useCdnResources() &&
-               (bootstrapCssReference == null ||
+            (bootstrapCssReference == null ||
                 bootstrapJavaScriptReference == null ||
                 modernizrJavaScriptReference == null);
     }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/settings/IBootstrapSettings.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/settings/IBootstrapSettings.java
@@ -49,6 +49,11 @@ public interface IBootstrapSettings {
     IBootstrapSettings setModernizrVersion(String version);
 
     /**
+     * @return the deferJavascript flag
+     */
+    boolean deferJavascript();
+
+    /**
      * @return The version of Twitter Bootstrap. CDN resources use it to construct their urls
      */
     String getVersion();
@@ -121,6 +126,14 @@ public interface IBootstrapSettings {
      * @return same instance for chaining
      */
     IBootstrapSettings setUpdateSecurityManager(boolean activate);
+
+    /**
+     * if true, the <script/> tag for the bootstrap javascript will get the defer="defer" attribute
+     *
+     * @param defer
+     * @return same instance for chaining
+     */
+    IBootstrapSettings setDeferJavascript(boolean defer);
 
     /**
      * if true, all necessary exceptions will be added to security manager to allow


### PR DESCRIPTION
Sometimes it's not desirable to defer the bootstrap-js, for example we're using a compiled bootstrap theme which has already all dependencies including jquery included into a single application.js file. 

In this case, deferring the bootstrap-js will cause wicket jquery errors.

Also, i've added an `.editorconfig` file to avoid accidental code-formatting issues :) 
