### PR TITLE
Deatach the labelResolved model in TooltipBehavior.onDeatch()

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehavior.java
@@ -50,6 +50,7 @@ public class TooltipBehavior extends BootstrapJavascriptBehavior {
         super.detach(component);
 
         label.detach();
+        labelResolved.detach();
     }
 
     @Override


### PR DESCRIPTION
Commit 5c4120dd1d17f7a819a544069a098bd1b93d7fc2 added a labelResolved model field, but does not detach it in onDetach().

This causes Wicket's NotDetachedModelChecker to fail any serialization of a page that contains TooltipBehaviour.
