### PR TITLE
[ModalCloseButton] Rework ModalCloseButton to be Ajax based

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalCloseButton.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalCloseButton.java
@@ -6,6 +6,8 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.button.Buttons;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -67,7 +69,9 @@ public class ModalCloseButton extends AjaxLink<String> {
     }
 
     @Override
-    public void onClick(AjaxRequestTarget target) {
+    protected void updateAjaxAttributes(AjaxRequestAttributes attributes) {
+        super.updateAjaxAttributes(attributes);
+
         Component _anchor = this.anchor;
         if (_anchor == null) {
             _anchor = findParent(Modal.class);
@@ -75,9 +79,16 @@ public class ModalCloseButton extends AjaxLink<String> {
         if (_anchor != null) {
             String anchorMarkupId = _anchor.getMarkupId();
             if (!Strings.isEmpty(anchorMarkupId)) {
-                target.appendJavaScript(String.format("document.location.hash='%s'", anchorMarkupId));
+                AjaxCallListener listener = new AjaxCallListener();
+                listener.onBeforeSend(String.format("document.location.hash='%s'", anchorMarkupId));
+                attributes.getAjaxCallListeners().add(listener);
             }
         }
+    }
+
+    @Override
+    public void onClick(AjaxRequestTarget target) {
+
     }
 
     public ModalCloseButton setAnchor(Modal<?> anchor) {


### PR DESCRIPTION
While testing with wicket-7.0.0-M1 branch I've noticed that ModalCloseButton refreshes the page.
With this PR I suggest to rework it to be Ajax based.
