### PR TITLE
Provide access to LessCompiler configuration

### DIFF
--- a/bootstrap-less/src/main/java/de/agilecoders/wicket/less/BootstrapLess.java
+++ b/bootstrap-less/src/main/java/de/agilecoders/wicket/less/BootstrapLess.java
@@ -6,6 +6,8 @@ import org.apache.wicket.markup.html.SecurePackageResourceGuard;
 import org.apache.wicket.request.resource.IResourceReferenceFactory;
 import org.apache.wicket.request.resource.ResourceReferenceRegistry;
 
+import com.github.sommeri.less4j.LessCompiler;
+
 /**
  * Bootstrap less compiler settings accessor class
  */
@@ -21,11 +23,12 @@ public final class BootstrapLess {
     /**
      * Installs given settings for given application
      *
-     * @param app      The current application
+     * @param app            The current application
+     * @param configFactory  The {@link LessCompilerConfigurationFactory} to create new {@link LessCompiler.Configuration}.
      */
-    public static void install(final Application app) {
+    public static void install(final Application app, final LessCompilerConfigurationFactory configFactory) {
 
-        LessCacheManager cacheManager = new LessCacheManager();
+        LessCacheManager cacheManager = new LessCacheManager(configFactory);
         cacheManager.install(app);
 
         IPackageResourceGuard resourceGuard = app.getResourceSettings().getPackageResourceGuard();
@@ -38,4 +41,14 @@ public final class BootstrapLess {
         IResourceReferenceFactory delegate = resourceReferenceRegistry.getResourceReferenceFactory();
         resourceReferenceRegistry.setResourceReferenceFactory(new LessResourceReferenceFactory(delegate));
     }
+    
+    /**
+     * Installs given settings for given application
+     *
+     * @param app      The current application
+     */
+    public static void install(final Application app) {
+        install(app, null);
+    }
+
 }

--- a/bootstrap-less/src/main/java/de/agilecoders/wicket/less/LessCacheManager.java
+++ b/bootstrap-less/src/main/java/de/agilecoders/wicket/less/LessCacheManager.java
@@ -27,6 +27,7 @@ public class LessCacheManager {
     private static final Logger LOG = LoggerFactory.getLogger(LessCacheManager.class);
 
     private static final MetaDataKey<LessCacheManager> KEY = new MetaDataKey<LessCacheManager>() {
+        private static final long serialVersionUID = 1L;
     };
 
     /**
@@ -42,6 +43,29 @@ public class LessCacheManager {
     private final ConcurrentMap<LessSource.URLSource, ConcurrentMap<Time, String>> contentCache =
             new ConcurrentHashMap<LessSource.URLSource, ConcurrentMap<Time, String>>();
 
+    /**
+     * A factory that creates {@link LessCompiler.Configuration}s.
+     */
+    private final LessCompilerConfigurationFactory configFactory;
+    
+    /**
+     * Creates a less cache manager with the {@link LessCompilerConfigurationFactory} provided.
+     * Choose this constructor if you want to use application specific configuration for example
+     * custom less functions.
+     * 
+     * @param configFactory The factory to use when creating a new {@link LessCompiler.Configuration}.
+     */
+    public LessCacheManager(LessCompilerConfigurationFactory configFactory) {
+        this.configFactory = configFactory != null ? configFactory : new SimpleLessCompilerConfigurationFactory();
+    }
+    
+    /**
+     * Creates a less cache manager with a {@link SimpleLessCompilerConfigurationFactory}.
+     */
+    public LessCacheManager() {
+        this(null);
+    }
+    
     /**
      * Returns the LessSource.URLSource per URL.
      * If there is no entry in the cache then it will be automatically registered
@@ -88,7 +112,7 @@ public class LessCacheManager {
             timeToContentMap.clear();
 
             ThreadUnsafeLessCompiler compiler = new ThreadUnsafeLessCompiler();
-            LessCompiler.Configuration configuration = new LessCompiler.Configuration();
+            LessCompiler.Configuration configuration = configFactory.newConfiguration();
             configuration.getSourceMapConfiguration().setLinkSourceMap(false);
 
             try {
@@ -155,6 +179,16 @@ public class LessCacheManager {
      */
     public void install(Application app) {
         app.setMetaData(KEY, this);
+    }
+    
+    /**
+     * Clears the CSS-cache to enable recomiling at runtime. This will clear the complete cache,
+     * not for a single .less-file.
+     * 
+     * @see #contentCache
+     */
+    public void clearCache() {
+        contentCache.clear();
     }
 
     /**

--- a/bootstrap-less/src/main/java/de/agilecoders/wicket/less/LessCompilerConfigurationFactory.java
+++ b/bootstrap-less/src/main/java/de/agilecoders/wicket/less/LessCompilerConfigurationFactory.java
@@ -1,0 +1,11 @@
+package de.agilecoders.wicket.less;
+
+import com.github.sommeri.less4j.LessCompiler;
+
+/**
+ * Factory that creates a {@link LessCompiler.Configuration}. This enables the users to set application
+ * specific configurations to the {@link LessCompiler}.
+ */
+public interface LessCompilerConfigurationFactory {
+    LessCompiler.Configuration newConfiguration();
+}

--- a/bootstrap-less/src/main/java/de/agilecoders/wicket/less/SimpleLessCompilerConfigurationFactory.java
+++ b/bootstrap-less/src/main/java/de/agilecoders/wicket/less/SimpleLessCompilerConfigurationFactory.java
@@ -1,0 +1,17 @@
+package de.agilecoders.wicket.less;
+
+import com.github.sommeri.less4j.LessCompiler;
+import com.github.sommeri.less4j.LessCompiler.Configuration;
+
+
+/**
+ * Returns just a plain {@link LessCompiler.Configuration} without any additional configuration.
+ */
+public class SimpleLessCompilerConfigurationFactory implements LessCompilerConfigurationFactory {
+
+    @Override
+    public Configuration newConfiguration() {
+        return new Configuration();
+    }
+
+}

--- a/bootstrap-less/src/test/java/de/agilecoders/wicket/less/LessCacheManagerTest.java
+++ b/bootstrap-less/src/test/java/de/agilecoders/wicket/less/LessCacheManagerTest.java
@@ -1,0 +1,103 @@
+package de.agilecoders.wicket.less;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.sommeri.less4j.LessSource;
+import com.github.sommeri.less4j.LessCompiler.Configuration;
+import com.github.sommeri.less4j.LessSource.URLSource;
+
+
+public class LessCacheManagerTest {
+    
+    private int invocationOfGetContent;
+    private int invocationOfNewConfiguration;
+
+    @Before
+    public void setUp() {
+        invocationOfGetContent = 0;
+        invocationOfNewConfiguration = 0;
+    }
+
+    /**
+     * Create a URLSource that keeps track of "getContent()" invocations.
+     */
+    protected URLSource createSampleURLSource() {
+        return new LessSource.URLSource(getClass().getResource("resources/root.less")) {
+            @Override
+            public String getContent() throws FileNotFound, CannotReadFile {
+                invocationOfGetContent++;
+                return super.getContent();
+            }
+        };
+    }
+
+    @Test
+    public void cachesCssResult() {
+        LessCacheManager cacheManager = new LessCacheManager();
+        
+        URLSource urlSource = createSampleURLSource();
+        
+        // LessSource.getContent() ist only necessary, when compiling the .less file.
+        // Otherwise the result would be in the cache.
+        
+        cacheManager.getCss(urlSource);
+        assertEquals(1, invocationOfGetContent);
+        
+        cacheManager.getCss(urlSource);
+        assertEquals(1, invocationOfGetContent);
+    }
+
+    @Test
+    public void clearCacheForcesRecompile() {
+        LessCacheManager cacheManager = new LessCacheManager();
+        
+        URLSource urlSource = createSampleURLSource();
+        
+        // LessSource.getContent() ist only necessary, when compiling the .less file.
+        // Otherwise the result would be in the cache.
+        
+        cacheManager.getCss(urlSource);
+        assertEquals(1, invocationOfGetContent);
+        
+        cacheManager.clearCache();
+        
+        cacheManager.getCss(urlSource);
+        assertEquals(2, invocationOfGetContent);
+    }
+    
+    @Test
+    public void usesLessCompilerConfigurationFactoryProvidedToCreateANewLesCompilerConfiguration() {
+        LessCacheManager cacheManager = new LessCacheManager(new LessCompilerConfigurationFactory() {
+            @Override
+            public Configuration newConfiguration() {
+                invocationOfNewConfiguration++;
+                return new Configuration();
+            }
+        });
+        
+        URLSource urlSource = createSampleURLSource();
+
+        cacheManager.getCss(urlSource);
+        assertEquals(1, invocationOfNewConfiguration);
+        
+        cacheManager.clearCache();
+
+        cacheManager.getCss(urlSource);
+        assertEquals(2, invocationOfNewConfiguration);
+    }
+    
+    @Test
+    public void usesDefaultConfigurationFactoryWhenProvidingNull() {
+        LessCacheManager cacheManager = new LessCacheManager(null);
+        
+        URLSource urlSource = createSampleURLSource();
+
+        cacheManager.getCss(urlSource);
+        
+        // no NullPointerException
+    }
+
+}

--- a/bootstrap-less/src/test/java/de/agilecoders/wicket/less/SimpleLessCompilerConfigurationFactoryTest.java
+++ b/bootstrap-less/src/test/java/de/agilecoders/wicket/less/SimpleLessCompilerConfigurationFactoryTest.java
@@ -1,0 +1,22 @@
+package de.agilecoders.wicket.less;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+
+import com.github.sommeri.less4j.LessCompiler;
+
+
+public class SimpleLessCompilerConfigurationFactoryTest {
+
+    @Test
+    public void createsASimplePlainLessCompilerConfiguration() {
+        SimpleLessCompilerConfigurationFactory factory = new SimpleLessCompilerConfigurationFactory();
+        LessCompiler.Configuration configuration = factory.newConfiguration();
+        
+        assertThat(configuration, instanceOf(LessCompiler.Configuration.class));
+        assertThat(configuration.getCustomFunctions(), empty());
+    }
+    
+}

--- a/bootstrap-less/src/test/java/de/agilecoders/wicket/less/resources/custom-functions.less
+++ b/bootstrap-less/src/test/java/de/agilecoders/wicket/less/resources/custom-functions.less
@@ -1,0 +1,5 @@
+@functionResult: myFancyFunction();
+
+.my-class {
+  color: @functionResult;
+}


### PR DESCRIPTION
Make it possible to provide a custom LessCompiler.Configuration with application specific data. For example to register custom less functions which can be used to change CSS properties at runtime.