### PR TITLE
Add missing FontAwesome database icon

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesomeIconType.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesomeIconType.java
@@ -132,6 +132,7 @@ public class FontAwesomeIconType extends IconType {
     public static final FontAwesomeIconType css3 = on(FontAwesomeIconTypeBuilder.FontAwesomeGraphic.css3).build();
     public static final FontAwesomeIconType cut = on(FontAwesomeIconTypeBuilder.FontAwesomeGraphic.cut).build();
     public static final FontAwesomeIconType cutlery = on(FontAwesomeGraphic.cutlery).build();
+    public static final FontAwesomeIconType database = on(FontAwesomeGraphic.database).build();
     public static final FontAwesomeIconType dashboard = on(FontAwesomeGraphic.dashboard).build();
     public static final FontAwesomeIconType dedent = on(FontAwesomeGraphic.dedent).build();
     public static final FontAwesomeIconType desktop = on(FontAwesomeGraphic.desktop).build();
@@ -449,7 +450,7 @@ public class FontAwesomeIconType extends IconType {
 
     /**
      * Constructor.
-     * 
+     *
      * @param cssClassName The css class name of the icon reference
      */
     FontAwesomeIconType(final String... cssClassName) {

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesomeIconTypeBuilder.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesomeIconTypeBuilder.java
@@ -39,7 +39,7 @@ public class FontAwesomeIconTypeBuilder {
         chevron_circle_right, chevron_circle_up, chevron_down, chevron_left, chevron_right, chevron_up, circle,
         circle_o, clipboard, clock_o, cloud, cloud_download, cloud_upload, cny, code, code_fork, coffee, cog, cogs,
         collapse, collapse_alt, collapse_top, columns, comment, comment_o, comments, comments_o, compass, compress,
-        copy, credit_card, crop, crosshairs, css3, cut, cutlery, dashboard, dedent, desktop, dot_circle_o, download,
+        copy, credit_card, crop, crosshairs, css3, cut, cutlery, database, dashboard, dedent, desktop, dot_circle_o, download,
         dribbble, dropbox, edit, eject, ellipsis_h, ellipsis_v, envelope, envelope_o, eraser, eur, exchange,
         exclamation, exclamation_circle, exclamation_triangle, expand, external_link, external_link_square, eye,
         eye_slash, facebook, facebook_square, fast_backward, fast_forward, female, fighter_jet, file, file_o,
@@ -179,7 +179,7 @@ public class FontAwesomeIconTypeBuilder {
 
     /**
      * make the icon spin
-     * 
+     *
      * @return the builder
      */
     public FontAwesomeIconTypeBuilder spin() {


### PR DESCRIPTION
The FontAwesome [database icon](http://fortawesome.github.io/Font-Awesome/icon/database/) was missing from the Java classes but present in the css. This commit adds it.