### PR TITLE
Fixes TypeAhead Bloodhound not working with Wicket URL encryption

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/typeaheadV10/bloodhound/Bloodhound.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/typeaheadV10/bloodhound/Bloodhound.java
@@ -67,7 +67,11 @@ public abstract class Bloodhound<T> extends AbstractAjaxBehavior implements Sour
     }
 
     protected CharSequence getRemoteUrl(String wildcard) {
-        return String.format("%s&%s=%s", getCallbackUrl(), QUERY_PARAM, wildcard);
+        String callbackUrl = getCallbackUrl().toString();
+        if (callbackUrl.contains("?")) {
+            return String.format("%s&%s=%s", callbackUrl, QUERY_PARAM, wildcard);
+        }
+        return String.format("%s?%s=%s", callbackUrl, QUERY_PARAM, wildcard);
     }
 
     @Override


### PR DESCRIPTION
This commit fixes the Autocomplete TypeAhead Bloodhound class
to work in combination with Wicket's URL encryption.
Originally the getRemoteUrl was malformed, there was no '?'
character denoting the start of the HTTP GET parameters.
Without URL encryption, Wicket happily accepted this malformed URL,
but when URL encryption is enabled it cannot properly decrypt
the malformed URL.