### PR TITLE
Fix Bloodhound.Remote JSON serialization

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/typeaheadV10/bloodhound/Remote.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/typeaheadV10/bloodhound/Remote.java
@@ -119,7 +119,7 @@ public class Remote extends AbstractConfig {
             if (remote.isSimple()) {
                 jsonGenerator.writeString(remote.getString(Url));
             } else {
-                jsonGenerator.writeString(remote.toJsonString());
+                jsonGenerator.writeRawValue(remote.toJsonString());
             }
 
         }

--- a/bootstrap-extensions/src/test/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/typeaheadV10/TypeaheadConfigTest.java
+++ b/bootstrap-extensions/src/test/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/typeaheadV10/TypeaheadConfigTest.java
@@ -54,7 +54,7 @@ public class TypeaheadConfigTest extends WicketApplicationTest {
         BloodhoundConfig config = new BloodhoundConfig();
         config.withRemote(remote);
 
-        String expected = "{\"datumTokenizer\":function(d) { return Bloodhound.tokenizers.whitespace(d.value); },\"queryTokenizer\":Bloodhound.tokenizers.whitespace,\"remote\":\"{\\\"url\\\":\\\"foo\\\",\\\"wildcard\\\":\\\"%FOO\\\"}\"}";
+        String expected = "{\"datumTokenizer\":function(d) { return Bloodhound.tokenizers.whitespace(d.value); },\"queryTokenizer\":Bloodhound.tokenizers.whitespace,\"remote\":{\"url\":\"foo\",\"wildcard\":\"%FOO\"}}";
         assertEquals(expected, config.toJsonString());
 
     }


### PR DESCRIPTION
I found bug in serialization of complex `typeaheadV10.bloodhound.Remote` configuration in TypeaheadV10 component.
Serializer uses `AbstractConfig.toJsonString` first and then writes it to output as string.
So configuration is serialized as string, not as JSON object and fetching from server doesn't work, because typeahead uses whole string as url.

Fixed by writing result of `AbstractConfig.toJsonString` as raw value.