### PR TITLE
Propagate upload error to the upload field

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/BootstrapFileInputField.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/BootstrapFileInputField.java
@@ -153,8 +153,8 @@ public class BootstrapFileInputField extends FileUploadField {
     public void renderHead(final IHeaderResponse response) {
         FileinputJsReference.INSTANCE.renderHead(response);
         
-        if(config.locale() != null)
-        	new FileinputLocaleJsReference(config.locale()).renderHead(response);
+        if(config.language() != null)
+        	new FileinputLocaleJsReference(config.language()).renderHead(response);
 
         JQuery fileinputJS = $(this).chain("fileinput", config);
 

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/BootstrapFileInputField.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/BootstrapFileInputField.java
@@ -124,6 +124,10 @@ public class BootstrapFileInputField extends FileUploadField {
                 target.add(getForm());
                 BootstrapFileInputField.this.onSubmit(target);
             }
+            @Override
+            protected void onError(AjaxRequestTarget target) {
+            	BootstrapFileInputField.this.onError(target);
+            }
         };
     }
 

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
@@ -51,7 +51,7 @@ public class FileInputConfig extends AbstractConfig {
 
     public static final IKey<List<String>> AllowedFileTypes = newKey("allowedFileTypes", null);
     
-    public static final IKey<String> Locale = newKey("locale", null);
+    public static final IKey<String> Language = newKey("language", null);
 
     public FileInputConfig showCaption(boolean showCaption) {
         put(ShowCaption, showCaption);
@@ -157,13 +157,13 @@ public class FileInputConfig extends AbstractConfig {
     }
     
     /**
-     * Sets fileinput locale. See {@link de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.res.locales}
+     * Sets fileinput language. See {@link de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.res.locales}
      * 
-     * @param locale
+     * @param language
      * @return config
      */
-    public FileInputConfig withLocale(String locale) {
-    	put(Locale, locale);
+    public FileInputConfig withLocale(String language) {
+    	put(Language, language);
     	return this;
     }
 
@@ -235,7 +235,7 @@ public class FileInputConfig extends AbstractConfig {
         return get(PreviewFileType);
     }
     
-    public String locale() {
-    	return get(Locale);
+    public String language() {
+    	return get(Language);
     }
 }


### PR DESCRIPTION
When uploading larger file then allowed, there is no way to hook to the onError and add notification panel to the target, for example.