### PR TITLE
Bugfix: Make BootstrapOrderByBorder compatible with wicket-7.7.0

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/sort/BootstrapOrderByBorder.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/sort/BootstrapOrderByBorder.java
@@ -44,8 +44,6 @@ public abstract class BootstrapOrderByBorder<S> extends Border {
 
 		addToBorder(link);
 
-		link.add(getBodyContainer());
-
 		WebMarkupContainer iconSort = new WebMarkupContainer("iconSort");
 		iconSort.setVisible(false);
 		link.add(iconSort);


### PR DESCRIPTION
Hi

Commit [321ccb814413cdc6cbbce7b3cdf24bc49e028aac](https://github.com/apache/wicket/commit/321ccb814413cdc6cbbce7b3cdf24bc49e028aac)) (`WICKET-6303 renderHead method of a Behavior added to a Border body is not called`) was commited on 16.01.17 to the [wicket repository](https://github.com/apache/wicket). It affected the class `OrderByBorder`, from which `BootstrapOrderByBorder` derives.

When I tried to upgrade to my project to wicket-7.7.0, my project would fail, both in tests and when running the application (using wicket-bootstrap-0.10.{12,13,14} and also with the latest 0.10.15.SNAPSHOT).  The error log is attached for reference below.

The commit from this pull request aligns `BootstrapOrderByBorder` with the changes in `OrderByBorder` from 16.01.17. wicket-bootstrap-0.10.15-SNAPSHOT built from my branch let's my project run successfully.

Hope this can be merged and hopefully released soon. Let me know if I should change something to make it mergeable.

Thanks and cheers
Urs

And here are the logs:

```
2017-06-02 17:09:30.628 ERROR 14040 --- [http-nio-8080-exec-1] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception

org.apache.wicket.WicketRuntimeException: An error occurred while detaching component: [BootstrapOrderByBorder [Component id = header, page = ch.difty.sipamato.web.pages.paper.list.PaperListPage, path = resultPanel:table:topToolbars:toolbars:2:headers:2:header, type = de.agilecoders.wicket.extensions.markup.html.bootstrap.table.sort.BootstrapOrderByBorder, isVisible = true, isVersioned = true, markup = [markup = jar:file:/var/local/m2/repository/org/apache/wicket/wicket-extensions/7.7.0/wicket-extensions-7.7.0.jar!/org/apache/wicket/extensions/markup/html/repeater/data/table/HeadersToolbar.html
<th wicket:id="header"><span wicket:id="label">[header-label]</span></th>, index = 0, current =  '<th wicket:id="header">' (line 0, column 0)]], children =  [OrderByLink [Component id = orderByLink]]]
	at org.apache.wicket.Component.detach(Component.java:1182)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.MarkupContainer.detachChildren(MarkupContainer.java:1761)
	at org.apache.wicket.Component.detach(Component.java:1187)
	at org.apache.wicket.core.request.handler.PageProvider.detach(PageProvider.java:330)
	at org.apache.wicket.core.request.handler.RenderPageRequestHandler.detach(RenderPageRequestHandler.java:156)
	at org.apache.wicket.request.cycle.RequestCycle$HandlerExecutor.detach(RequestCycle.java:906)
	at org.apache.wicket.request.RequestHandlerStack.detach(RequestHandlerStack.java:180)
	at org.apache.wicket.request.cycle.RequestCycle.onDetach(RequestCycle.java:641)
	at org.apache.wicket.request.cycle.RequestCycle.detach(RequestCycle.java:594)
	at org.apache.wicket.request.cycle.RequestCycle.processRequestAndDetach(RequestCycle.java:297)
	at org.apache.wicket.protocol.http.WicketFilter.processRequestCycle(WicketFilter.java:261)
	at org.apache.wicket.protocol.http.WicketFilter.processRequest(WicketFilter.java:203)
	at org.apache.wicket.protocol.http.WicketFilter.doFilter(WicketFilter.java:284)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.boot.web.filter.ApplicationContextHeaderFilter.doFilterInternal(ApplicationContextHeaderFilter.java:55)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.boot.actuate.trace.WebRequestTraceFilter.doFilterInternal(WebRequestTraceFilter.java:110)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:317)
	at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.invoke(FilterSecurityInterceptor.java:127)
	at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.doFilter(FilterSecurityInterceptor.java:91)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:114)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:137)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:111)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:170)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:116)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:64)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:105)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:56)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:214)
	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:177)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:346)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:262)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:99)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.HttpPutFormContentFilter.doFilterInternal(HttpPutFormContentFilter.java:105)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.HiddenHttpMethodFilter.doFilterInternal(HiddenHttpMethodFilter.java:81)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:197)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.boot.actuate.autoconfigure.MetricsFilter.doFilterInternal(MetricsFilter.java:106)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198)
	at org.apache.catalina.core.StandardContextValve.__invoke(StandardContextValve.java:96)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:478)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:80)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:799)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:861)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1455)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.wicket.WicketRuntimeException: Detach called on component with id 'header' while it had a non-empty queue: ComponentQueue{queueSize=1, queue=[[BorderBodyContainer [Component id = header_body]], null, null, null, null, null, null, null]}
	at org.apache.wicket.MarkupContainer.onDetach(MarkupContainer.java:1943)
	at org.apache.wicket.Component.detach(Component.java:1163)
	... 103 common frames omitted

2017-06-02 17:09:43.102 ERROR 14040 --- [http-nio-8080-exec-4] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
```