### PR TITLE
Refactor Icon and IconType to be able to use Material icons

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/Icon.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/Icon.java
@@ -1,8 +1,12 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.image;
 
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+
+import de.agilecoders.wicket.core.util.Components;
 
 /**
  * An Icon component displays a non localizable image resource.
@@ -11,7 +15,9 @@ import org.apache.wicket.model.Model;
  * @version 1.0
  */
 public class Icon extends WebMarkupContainer {
-
+    /** serialVersionUID. */
+    private static final long serialVersionUID = 1L;
+    /** Icon behavior. */
     private final IconBehavior iconBehavior;
 
     /**
@@ -24,14 +30,25 @@ public class Icon extends WebMarkupContainer {
         add(iconBehavior = new IconBehavior(type));
     }
 
-    public Icon(final IModel<IconType> type) {
-        this("icon", type);
+    /**
+     * @param typeModel the model containing the icon type
+     */
+    public Icon(final IModel<IconType> typeModel) {
+        this("icon", typeModel);
     }
 
+    /**
+     * @param id the component id
+     * @param type the icon type
+     */
     public Icon(final String id, final IconType type) {
         this(id, Model.of(type));
     }
 
+    /**
+     * 
+     * @param type the icon type
+     */
     public Icon(final IconType type) {
         this("icon", Model.of(type));
     }
@@ -66,7 +83,20 @@ public class Icon extends WebMarkupContainer {
      * @return current icon type
      */
     public IconType type() {
-        return iconBehavior.type();
+        return getType();
     }
 
+    @Override
+    public void onComponentTagBody(MarkupStream markupStream, ComponentTag openTag) {
+        super.onComponentTagBody(markupStream, openTag);
+        if(hasIconType() && getType().getTagBody() != null) {
+            replaceComponentTagBody(markupStream, openTag, getType().getTagBody());
+        }
+    }
+
+    @Override
+    protected void onComponentTag(ComponentTag tag) {
+        super.onComponentTag(tag);
+        Components.assertTag(this, tag, "i", "span");
+    }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/Icon.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/Icon.java
@@ -6,8 +6,6 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
-import de.agilecoders.wicket.core.util.Components;
-
 /**
  * An Icon component displays a non localizable image resource.
  *
@@ -88,15 +86,11 @@ public class Icon extends WebMarkupContainer {
 
     @Override
     public void onComponentTagBody(MarkupStream markupStream, ComponentTag openTag) {
-        super.onComponentTagBody(markupStream, openTag);
         if(hasIconType() && getType().getTagBody() != null) {
             replaceComponentTagBody(markupStream, openTag, getType().getTagBody());
+        } else {
+            super.onComponentTagBody(markupStream, openTag);
         }
     }
-
-    @Override
-    protected void onComponentTag(ComponentTag tag) {
-        super.onComponentTag(tag);
-        Components.assertTag(this, tag, "i", "span");
-    }
 }
+

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/IconType.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/IconType.java
@@ -15,7 +15,7 @@ public abstract class IconType implements ICssClassNameProvider, ICssClassNameMo
     private static final long serialVersionUID = 1L;
     /** CSS classname. */
     private final String cssClassName;
-    /** The body of the tag (for material icons &lti class="material-icon"&gttag-body&lt/i&gt). */
+    /** The body of the tag (for material icons &lt;i class="material-icon"&gt;tag-body&lt;/i&gt;). */
     private final String tagBody;
 
     /**
@@ -33,7 +33,7 @@ public abstract class IconType implements ICssClassNameProvider, ICssClassNameMo
      * Constructor.
      *
      * @param cssClassName The css class name of the icon reference
-     * @param tagBody the body of the tag (for material icons &lti class="material-icons"&gttag-content&lt/i&gt)
+     * @param tagBody the body of the tag (for material icons &lt;i class="material-icons"&gt;tag-content&lt;/i&gt;)
      */
     protected IconType(String cssClassName, String tagBody) {
         Args.notEmpty(cssClassName, "cssClassName");

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/IconType.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/IconType.java
@@ -4,14 +4,19 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameApp
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameModifier;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.util.lang.Args;
 
 /**
  * References all available icons inside the icon sprite.
  */
 public abstract class IconType implements ICssClassNameProvider, ICssClassNameModifier {
+    /** serialVersionUID. */
+    private static final long serialVersionUID = 1L;
     /** CSS classname. */
-    private String cssClassName;
+    private final String cssClassName;
+    /** The body of the tag (for material icons &lti class="material-icon"&gttag-body&lt/i&gt). */
+    private final String tagBody;
 
     /**
      * Constructor.
@@ -21,6 +26,20 @@ public abstract class IconType implements ICssClassNameProvider, ICssClassNameMo
     protected IconType(String cssClassName) {
         Args.notEmpty(cssClassName, "cssClassName");
         this.cssClassName = cssClassName.toLowerCase();
+        tagBody = null;
+    }
+    
+    /**
+     * Constructor.
+     *
+     * @param cssClassName The css class name of the icon reference
+     * @param tagBody the body of the tag (for material icons <i class="material-icons">tag-content</i>)
+     */
+    protected IconType(String cssClassName, String tagBody) {
+        Args.notEmpty(cssClassName, "cssClassName");
+        Args.notEmpty(tagBody, "tagContent");
+        this.cssClassName = cssClassName.toLowerCase();
+        this.tagBody = tagBody.toLowerCase();        
     }
 
 	/**
@@ -34,4 +53,12 @@ public abstract class IconType implements ICssClassNameProvider, ICssClassNameMo
     public CssClassNameAppender newCssClassNameModifier() {
         return new CssClassNameAppender(getCssClassName());
     }
+
+    /**
+     * @return the tag content
+     */
+    public String getTagBody() {
+        return tagBody;
+    }
 }
+

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/IconType.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/image/IconType.java
@@ -33,7 +33,7 @@ public abstract class IconType implements ICssClassNameProvider, ICssClassNameMo
      * Constructor.
      *
      * @param cssClassName The css class name of the icon reference
-     * @param tagBody the body of the tag (for material icons <i class="material-icons">tag-content</i>)
+     * @param tagBody the body of the tag (for material icons &lti class="material-icons"&gttag-content&lt/i&gt)
      */
     protected IconType(String cssClassName, String tagBody) {
         Args.notEmpty(cssClassName, "cssClassName");


### PR DESCRIPTION
PR for #700

Glyphicon and fontawesome syntax
`<i class="fa fa-address-book"></i>`

Material icons syntax
`<i class="material-icons">3d_rotation</i>

So I'have added a "tag body" field in the IconBehavior.
In the Icon class I do like a Label : I override `onComponentTagBody` if the tag body is provided.

An exemple of the MaterialIconType I've done :
```java
public class MaterialIconType extends IconType {
    /** serialVersionUID. */
    private static final long serialVersionUID = 1L;
    /** Material icons class. */
    private static final String MATERIAL_ICONS = "material-icons";

    public static final MaterialIconType threed_rotation = new MaterialIconType(MATERIAL_ICONS, "3d_rotation");
    public static final MaterialIconType input = new MaterialIconType(MATERIAL_ICONS, "input");
    public static final MaterialIconType dashboard = new MaterialIconType(MATERIAL_ICONS, "dashboard");

    /**
     * @param paramCssClassName the css classname
     * @param paramTagContent the tag body
     */
    protected MaterialIconType(final String cssClassName, final String tagBody) {
        super(cssClassName, tagBody);
    }

    @Override
    public String cssClassName() {
        return getCssClassName();
    }

}
```

I've also updated the javadoc.

Let me know if i need to tweak some more codes.