### PR TITLE
button/link : be able to not use the splitter

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapAjaxButton.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapAjaxButton.java
@@ -26,6 +26,8 @@ public abstract class BootstrapAjaxButton extends AjaxButton implements IBootstr
     private final Component label;
     private final Component splitter;
     private final ButtonBehavior buttonBehavior;
+    /** To use the splitter or not (true by default). */
+    private boolean useSplitter = true;
 
     /**
      * Construct.
@@ -100,7 +102,7 @@ public abstract class BootstrapAjaxButton extends AjaxButton implements IBootstr
 
     /**
      * creates a new splitter component. The splitter is visible only
-     * if icon is visible.
+     * if icon is visible and useSplitter is true.
      *
      * @param markupId the component id of the splitter
      * @return new splitter component
@@ -108,7 +110,8 @@ public abstract class BootstrapAjaxButton extends AjaxButton implements IBootstr
     protected Component newSplitter(final String markupId) {
         return new WebMarkupContainer(markupId)
                 .setRenderBodyOnly(true)
-                .setEscapeModelStrings(false);
+                .setEscapeModelStrings(false)
+                .setVisible(false);
     }
 
     /**
@@ -123,7 +126,9 @@ public abstract class BootstrapAjaxButton extends AjaxButton implements IBootstr
     protected void onConfigure() {
         super.onConfigure();
 
-        splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(label.getDefaultModelObjectAsString()));
+        if(useSplitter) {
+            splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(label.getDefaultModelObjectAsString()));
+        }
     }
 
     /**
@@ -168,6 +173,15 @@ public abstract class BootstrapAjaxButton extends AjaxButton implements IBootstr
      */
     public BootstrapAjaxButton setType(Buttons.Type type) {
         this.buttonBehavior.setType(type);
+        return this;
+    }
+    
+    /**
+     * @param value whether to use splitter between the icon and the label or not
+     * @return this instance for chaining
+     */
+    public BootstrapAjaxButton useSplitter(boolean value) {
+        this.useSplitter = value;
         return this;
     }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapAjaxFallbackButton.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapAjaxFallbackButton.java
@@ -2,6 +2,9 @@ package de.agilecoders.wicket.core.markup.html.bootstrap.button;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
+
+import java.io.Serializable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.markup.html.form.AjaxFallbackButton;
@@ -21,10 +24,12 @@ import org.apache.wicket.model.Model;
 public abstract class BootstrapAjaxFallbackButton extends AjaxFallbackButton implements IBootstrapButton<BootstrapAjaxFallbackButton> {
 
     private final Icon icon;
-    private final Label label;
+    private final Component label;
     private final Component splitter;
     private final ButtonBehavior buttonBehavior;
-
+    /** To use the splitter or not (true by default). */
+    private boolean useSplitter = true;
+    
     /**
      * Construct.
      *
@@ -48,10 +53,10 @@ public abstract class BootstrapAjaxFallbackButton extends AjaxFallbackButton imp
         super(id, model, form);
 
         add(buttonBehavior = new ButtonBehavior(type, Buttons.Size.Medium));
-        add(icon = new Icon("icon", (IconType) null));
-        add(splitter = new WebMarkupContainer("splitter"));
+        add(icon = newIcon("icon"));
+        add(splitter = newSplitter("splitter"));
 
-        this.label = new Label("label", model);
+        this.label = newLabel("label", model);
         this.label.setRenderBodyOnly(true);
         add(label);
     }
@@ -63,12 +68,50 @@ public abstract class BootstrapAjaxFallbackButton extends AjaxFallbackButton imp
     protected IMarkupSourcingStrategy newMarkupSourcingStrategy() {
         return new PanelMarkupSourcingStrategy(true);
     }
+    
+    
+    /**
+     * creates a new icon component
+     *
+     * @param markupId the component id of the icon
+     * @return new icon component
+     */
+    protected Icon newIcon(final String markupId) {
+        return new Icon(markupId, (IconType) null);
+    }
+    
+    /**
+     * creates a new label component
+     *
+     * @param markupId the component id of the label
+     * @return new label component
+     */
+    protected <L extends Serializable> Component newLabel(final String markupId, IModel<L> model) {
+        return new Label(markupId, model)
+                .setRenderBodyOnly(true);
+    }
+    
+    /**
+     * creates a new splitter component. The splitter is visible only
+     * if icon is visible and useSplitter is true.
+     *
+     * @param markupId the component id of the splitter
+     * @return new splitter component
+     */
+    protected Component newSplitter(final String markupId) {
+        return new WebMarkupContainer(markupId)
+                .setRenderBodyOnly(true)
+                .setEscapeModelStrings(false)
+                .setVisible(false);
+    }
 
     @Override
     protected void onConfigure() {
         super.onConfigure();
 
-        splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(getModelObject()));
+        if(useSplitter) {
+            splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(getModelObject()));
+        }
     }
 
     /**
@@ -80,7 +123,8 @@ public abstract class BootstrapAjaxFallbackButton extends AjaxFallbackButton imp
     @Override
     public BootstrapAjaxFallbackButton setLabel(IModel<String> label) {
         this.label.setDefaultModel(label);
-
+        //the label is also in the button model
+        setModel(label);
         return this;
     }
 
@@ -120,4 +164,12 @@ public abstract class BootstrapAjaxFallbackButton extends AjaxFallbackButton imp
         return this;
     }
 
+    /**
+     * @param value whether to use splitter between the icon and the label or not
+     * @return this instance for chaining
+     */
+    public BootstrapAjaxFallbackButton useSplitter(boolean value) {
+        this.useSplitter = value;
+        return this;
+    }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapAjaxLink.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapAjaxLink.java
@@ -26,6 +26,8 @@ public abstract class BootstrapAjaxLink<T> extends AjaxLink<T> implements IBoots
     private final Component label;
     private final Component splitter;
     private final ButtonBehavior buttonBehavior;
+    /** To use the splitter or not (true by default). */
+    private boolean useSplitter = true;
 
     /**
      * Construct.
@@ -92,7 +94,7 @@ public abstract class BootstrapAjaxLink<T> extends AjaxLink<T> implements IBoots
 
    /**
     * Creates a new splitter component. The splitter is visible only
-    * if icon is visible.
+    * if icon is visible and useSplitter is true.
     *
     * @param markupId the component id of the splitter
     * @return new splitter component
@@ -100,7 +102,8 @@ public abstract class BootstrapAjaxLink<T> extends AjaxLink<T> implements IBoots
    protected Component newSplitter(final String markupId) {
        return new WebMarkupContainer(markupId)
                .setRenderBodyOnly(true)
-               .setEscapeModelStrings(false);
+               .setEscapeModelStrings(false)
+               .setVisible(false);
    }
 
     /**
@@ -115,7 +118,9 @@ public abstract class BootstrapAjaxLink<T> extends AjaxLink<T> implements IBoots
     protected void onConfigure() {
         super.onConfigure();
 
-        splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(label.getDefaultModelObjectAsString()));
+        if(useSplitter) {
+            splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(label.getDefaultModelObjectAsString()));
+        }
     }
 
     /**
@@ -160,4 +165,12 @@ public abstract class BootstrapAjaxLink<T> extends AjaxLink<T> implements IBoots
         return this;
     }
 
+    /**
+     * @param value whether to use splitter between the icon and the label or not
+     * @return this instance for chaining
+     */
+    public BootstrapAjaxLink<T> useSplitter(boolean value) {
+        this.useSplitter = value;
+        return this;
+    }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapButton.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapButton.java
@@ -1,5 +1,6 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.button;
 
+import de.agilecoders.wicket.core.markup.html.bootstrap.form.FormGroup;
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import org.apache.commons.lang3.StringUtils;
@@ -17,11 +18,17 @@ import org.apache.wicket.model.IModel;
  * @author miha
  */
 public class BootstrapButton extends Button implements IBootstrapButton<BootstrapButton> {
-
+    /** The icon of the button. */
     private final Icon icon;
+    /** The label of the button. */
     private final Component label;
+    /** The splitter (space between the icon and the label. */
     private final Component splitter;
+    /** The button behavior. */
     private final ButtonBehavior buttonBehavior;
+    /** To use the splitter or not (true by default). */
+    private boolean useSplitter = true;
+    
 
     /**
      * Construct.
@@ -73,7 +80,7 @@ public class BootstrapButton extends Button implements IBootstrapButton<Bootstra
 
     /**
      * creates a new splitter component. The splitter is visible only
-     * if icon is visible.
+     * if icon is visible or if useSplitter is true.
      *
      * @param markupId the component id of the splitter
      * @return new splitter component
@@ -81,14 +88,17 @@ public class BootstrapButton extends Button implements IBootstrapButton<Bootstra
     protected Component newSplitter(final String markupId) {
         return new WebMarkupContainer(markupId)
                 .setRenderBodyOnly(true)
-                .setEscapeModelStrings(false);
+                .setEscapeModelStrings(false)
+                .setVisible(false);
     }
 
     @Override
     protected void onConfigure() {
         super.onConfigure();
 
-        splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(getModelObject()));
+        if (useSplitter) {
+            splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(getModelObject()));
+        }
     }
 
     /**
@@ -108,6 +118,8 @@ public class BootstrapButton extends Button implements IBootstrapButton<Bootstra
     @Override
     public BootstrapButton setLabel(IModel<String> label) {
         this.label.setDefaultModel(label);
+        //the label is also store in the button's model
+        setModel(label);
 
         return this;
     }
@@ -137,4 +149,12 @@ public class BootstrapButton extends Button implements IBootstrapButton<Bootstra
         return this;
     }
 
+    /**
+     * @param value whether to use splitter between the icon and the label or not
+     * @return this instance for chaining
+     */
+    public BootstrapButton useSplitter(boolean value) {
+        this.useSplitter = value;
+        return this;
+    }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapLink.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/BootstrapLink.java
@@ -18,6 +18,7 @@ import org.apache.wicket.model.Model;
  * <p>
  * You can use a link like:
  * <p/>
+ * 
  * <pre>
  * add(new BootstrapLink(&quot;myLink&quot;)
  * {
@@ -30,6 +31,7 @@ import org.apache.wicket.model.Model;
  * <p/>
  * and in your HTML file:
  * <p/>
+ * 
  * <pre>
  *  &lt;a href=&quot;#&quot; wicket:id=&quot;myLink&quot;&gt;click here&lt;/a&gt;
  * </pre>
@@ -38,6 +40,7 @@ import org.apache.wicket.model.Model;
  * The following snippet shows how to pass a parameter from the Page creating the Page to the Page
  * responded by the Link.
  * <p/>
+ * 
  * <pre>
  * add(new BootstrapLink&lt;MyObject&gt;(&quot;link&quot;, listItem.getModel(), Type.Primary )
  * {
@@ -56,11 +59,13 @@ public abstract class BootstrapLink<T> extends Link<T> implements IBootstrapButt
     private final Component label;
     private final Component splitter;
     private final ButtonBehavior buttonBehavior;
+    /** To use the splitter or not (true by default). */
+    private boolean useSplitter = true;
 
     /**
      * Construct.
      *
-     * @param id    the components id
+     * @param id the components id
      * @param model mandatory parameter
      */
     public BootstrapLink(final String id, final IModel<T> model) {
@@ -70,7 +75,7 @@ public abstract class BootstrapLink<T> extends Link<T> implements IBootstrapButt
     /**
      * Construct.
      *
-     * @param id   the components id
+     * @param id the components id
      * @param type the type of the button
      */
     public BootstrapLink(final String id, final Buttons.Type type) {
@@ -80,9 +85,9 @@ public abstract class BootstrapLink<T> extends Link<T> implements IBootstrapButt
     /**
      * Construct.
      *
-     * @param id    The component id
+     * @param id The component id
      * @param model mandatory parameter
-     * @param type  the type of the button
+     * @param type the type of the button
      */
     public BootstrapLink(final String id, final IModel<T> model, final Buttons.Type type) {
         super(id, model);
@@ -111,21 +116,18 @@ public abstract class BootstrapLink<T> extends Link<T> implements IBootstrapButt
      * @return new label component
      */
     protected Component newLabel(final String markupId) {
-        return new Label(markupId, new Model<>(""))
-                .setRenderBodyOnly(true);
+        return new Label(markupId, new Model<>("")).setRenderBodyOnly(true);
     }
 
     /**
      * creates a new splitter component. The splitter is visible only
-     * if icon is visible.
+     * if icon is visible and useSplitter is true.
      *
      * @param markupId the component id of the splitter
      * @return new splitter component
      */
     protected Component newSplitter(final String markupId) {
-        return new WebMarkupContainer(markupId)
-                .setRenderBodyOnly(true)
-                .setEscapeModelStrings(false);
+        return new WebMarkupContainer(markupId).setRenderBodyOnly(true).setEscapeModelStrings(false).setVisible(false);
     }
 
     /**
@@ -140,7 +142,9 @@ public abstract class BootstrapLink<T> extends Link<T> implements IBootstrapButt
     protected void onConfigure() {
         super.onConfigure();
 
-        splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(label.getDefaultModelObjectAsString()));
+        if (useSplitter) {
+            splitter.setVisible(icon.hasIconType() && StringUtils.isNotEmpty(label.getDefaultModelObjectAsString()));
+        }
     }
 
     /**
@@ -186,7 +190,7 @@ public abstract class BootstrapLink<T> extends Link<T> implements IBootstrapButt
         this.buttonBehavior.setType(type);
         return this;
     }
-    
+
     /**
      * Sets whether this button should display inline or block
      *
@@ -194,7 +198,16 @@ public abstract class BootstrapLink<T> extends Link<T> implements IBootstrapButt
      * @return this instance for chaining
      */
     public BootstrapLink<T> setBlock(boolean block) {
-    	this.buttonBehavior.setBlock(block);
-    	return this;
+        this.buttonBehavior.setBlock(block);
+        return this;
+    }
+
+    /**
+     * @param value whether to use splitter between the icon and the label or not
+     * @return this instance for chaining
+     */
+    public BootstrapLink<T> useSplitter(boolean value) {
+        this.useSplitter = value;
+        return this;
     }
 }


### PR DESCRIPTION
I've got a use case where I don't want the splitter (&nbsp;) between the icon and the label (my label contains html code) in the buttons or links.
For exemple when I put HTML code in the label.

So I've added a `useSplitter(boolean value)` in all the Button and Link.

I've also fix the `setLabel(IModel<String> label)` not updating the button's model as the model is store in
the label and also in the button.

The BootstrapAjaxFallbackButton class is now similar as the other buttons/links (with newLabel, newIcon, newSplitter functions).

how to disable the splitter : 
```java
new BootstrapLink<Void>("dashboardLink", Type.Menu) {
            public void onClick() {
                // TODO task
            }
        }.useSplitter(false).setIconType(FontAwesomeIconType.dashboard).setLabel(Model.of("Dashboard"))
```