### PR TITLE
Added render test for Modal

### DIFF
--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTest.java
@@ -3,6 +3,10 @@ package de.agilecoders.wicket.core.markup.html.bootstrap.dialog;
 import de.agilecoders.wicket.core.WicketApplicationTest;
 import org.junit.Test;
 
+/**
+ * Test ensures the Modal component renders without throwing an exception. This test
+ * was originally created for this issue https://github.com/l0rdn1kk0n/wicket-bootstrap/issues/713.
+ */
 public class ModalTest extends WicketApplicationTest
 {
     private static final String MARKUP = "<html><head></head><body><div wicket:id=\"id\"></div></body></html>'";

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTest.java
@@ -1,0 +1,16 @@
+package de.agilecoders.wicket.core.markup.html.bootstrap.dialog;
+
+import de.agilecoders.wicket.core.WicketApplicationTest;
+import org.junit.Test;
+
+public class ModalTest extends WicketApplicationTest
+{
+    private static final String MARKUP = "<html><head></head><body><div wicket:id=\"id\"></div></body></html>'";
+
+    @Test
+    public void rendersWithoutException()
+    {
+        startComponentInPage(new ModalTestPanel(id()), MARKUP);
+    }
+
+}

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTestPanel.html
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTestPanel.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:extend>
+    <form wicket:id="form">
+        <div class="form-group">
+            <label>Filter name</label>
+            <input type="text" wicket:id="title" class="form-control" placeholder="Filter name"></input>
+        </div>
+    </form>
+</wicket:extend>
+</body>
+</html>

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTestPanel.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTestPanel.java
@@ -6,6 +6,10 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.RequiredTextField;
 import org.apache.wicket.model.Model;
 
+/**
+ * Simple Modal that adds a button via the addButton method to ensure it renders properly when
+ * buttons are added.
+ */
 public class ModalTestPanel extends Modal<String>
 {
     public ModalTestPanel(String id)

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTestPanel.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/ModalTestPanel.java
@@ -1,0 +1,30 @@
+package de.agilecoders.wicket.core.markup.html.bootstrap.dialog;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.RequiredTextField;
+import org.apache.wicket.model.Model;
+
+public class ModalTestPanel extends Modal<String>
+{
+    public ModalTestPanel(String id)
+    {
+        super(id);
+
+        setOutputMarkupId(true);
+
+        Form<Void> form = new Form<Void>("form");
+        form.add(new RequiredTextField<>("title"));
+
+        addButton(new AjaxLink<Void>(Modal.BUTTON_MARKUP_ID)
+        {
+            @Override
+            public void onClick(AjaxRequestTarget target)
+            {
+                close(target);
+            }
+        }.setBody(Model.of("Save")));
+        add(form);
+    }
+}


### PR DESCRIPTION
I added a render test for the Modal component. I noticed that the bug I reported in #713 has been fixed. The wicket:fragment has been changed to wicket:component. I ensured my test was valid by changing the html back to wicket:fragment and I got the same stack trace I was getting in 0.10.6. 

Thanks I think you can close this one.