### PR TITLE
version bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
         <jquerypp.version>1.0.1</jquerypp.version>
         <jquery.version>2.2.4</jquery.version>
         <maven-bundle-plugin.version>2.5.4</maven-bundle-plugin.version>
-        <wicket.version>7.7.0</wicket.version>
-        <wicketstuff.version>7.7.0</wicketstuff.version>
+        <wicket.version>7.10.0</wicket.version>
+        <wicketstuff.version>7.10.0</wicketstuff.version>
         <yuicompressor.version>2.4.8</yuicompressor.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <guava.version>19.0</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <!-- TODO -->
         <servlet-api.version>3.0.1</servlet-api.version>
         <javax.javaee-web-api.version>7.0</javax.javaee-web-api.version>
-        <versions-maven-plugin.version>2.2</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
         <doxia.version>1.0</doxia.version>
         <less4j.version>1.17.2</less4j.version>
         <modernizr.version>2.8.3</modernizr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <wicketstuff.version>7.10.0</wicketstuff.version>
         <yuicompressor.version>2.4.8</yuicompressor.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>20.0</guava.version>
         <junit.version>4.12</junit.version>
         <logback.version>1.2.2</logback.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
         <guava.version>20.0</guava.version>
         <junit.version>4.12</junit.version>
-        <logback.version>1.2.2</logback.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <wicket.version>7.10.0</wicket.version>
         <wicketstuff.version>7.10.0</wicketstuff.version>
         <yuicompressor.version>2.4.8</yuicompressor.version>
-        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
         <guava.version>20.0</guava.version>
         <junit.version>4.12</junit.version>
         <logback.version>1.2.2</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
+                <version>3.7</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>2.5.3</version>
                 <configuration>
                     <goals>deploy</goals>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <bootstrap.version>3.3.7-1</bootstrap.version>
         <config.version>0.3.5</config.version>
         <wicket-webjars.version>0.5.6</wicket-webjars.version>
-        <wicket-jquery-selectors.version>0.2.5</wicket-jquery-selectors.version>
+        <wicket-jquery-selectors.version>0.2.6</wicket-jquery-selectors.version>
 
         <enforcer.disable>true</enforcer.disable>
         <pmd.disable>true</pmd.disable>


### PR DESCRIPTION
Hi

This pull request bumps the version of some dependencies. Initial target was wicket (7.10.0), taking with it guava, logback, commons-lang3, jquery-selectors and some of the maven-plugins.

Thanks and cheers
Urs