### PR TITLE
build with openjdk7 since travis' trusty does not support openjdk6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk6
+  - openjdk7
 
 after_failure:
   - "cat bootstrap-core/target/surefire-reports/de.agilecoders.wicket.core.markup.html.bootstrap.button.dropdown.DropDownButtonTest.txt"


### PR DESCRIPTION
see https://github.com/travis-ci/travis-ci/issues/8199

This PR makes the build compile with openjdk7 but  does not fix the copertura test coverage issue:
`Could not find goal 'cobertura' in plugin org.eluder.coveralls:coveralls-maven-plugin:3.1.0 among available goals report`
