### PR TITLE
BootstrapToggle - fix for checkbox' label model

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/checkbox/bootstraptoggle/BootstrapToggle.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/checkbox/bootstraptoggle/BootstrapToggle.java
@@ -54,23 +54,23 @@ public class BootstrapToggle extends BootstrapCheckbox {
      * Constructor.
      *
      * @param id The component id
-     * @param model The model to keep the selection
-     * @param config The configuration of this Bootstrap widget
-     */
-    public BootstrapToggle(String id, IModel<Boolean> model, BootstrapToggleConfig config) {
-        super(id, model);
-
-        this.config = Args.notNull(config, "config");
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param id The component id
      * @param config The configuration of this Bootstrap widget
      */
     public BootstrapToggle(String id, BootstrapToggleConfig config) {
         this(id, null, config);
+    }    
+    
+    /**
+     * Constructor.
+     *
+     * @param id The component id
+     * @param model The model to keep the selection
+     * @param config The configuration of this Bootstrap widget
+     */
+    public BootstrapToggle(String id, IModel<Boolean> model, BootstrapToggleConfig config) {
+        super(id, model, Model.of(""));
+
+        this.config = Args.notNull(config, "config");
     }
 
     @Override


### PR DESCRIPTION
Passing empty model for checkbox label for the case of using the BootstrapToggle in the component with CompoundPropertyModel where component tries to find a model for a label and tries that with a "post-label" property expression on a CPM's object.  