### PR TITLE
Wicket 8.x - BootstrapLabel component and text and choice filter property columns

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/label/BootstrapLabel.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/label/BootstrapLabel.java
@@ -1,0 +1,37 @@
+package de.agilecoders.wicket.core.markup.html.bootstrap.label;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.IModel;
+
+/**
+ * Bootstrapified Label.
+ * <p>
+ * <pre>
+ *     	<span class="label">Default</span>
+ *     	<span class="label label-primary">Primary</span>
+ *     	<span class="label label-success">Success</span>
+ *     	<span class="label label-warning">Warning</span>
+ *     	<span class="label label-info">Info</span>
+ *     	<span class="label label-danger">Danger</span>
+ * </pre>
+ *
+ * @author drummer
+ */
+public class BootstrapLabel extends Label {
+
+    private final LabelBehaviour labelBehaviour;
+
+    public BootstrapLabel(final String componentId, final Labels.Type type) {
+        this(componentId, null, type);
+    }
+
+    public BootstrapLabel(final String componentId, final IModel<String> model, final Labels.Type type) {
+        super(componentId, model);
+        add(labelBehaviour = new LabelBehaviour(type));
+    }
+
+    public BootstrapLabel setType(final Labels.Type type) {
+        labelBehaviour.setType(type);
+        return this;
+    }
+}

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/label/LabelBehaviour.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/label/LabelBehaviour.java
@@ -1,0 +1,44 @@
+package de.agilecoders.wicket.core.markup.html.bootstrap.label;
+
+import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.BootstrapBaseBehavior;
+import de.agilecoders.wicket.core.util.Components;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+/**
+ * Default label behavior that controls the size and type
+ * of a label.
+ *
+ * @author drummer
+ */
+public class LabelBehaviour extends BootstrapBaseBehavior {
+
+    private final IModel<Labels.Type> labelType;
+
+    public LabelBehaviour() {
+        this(Labels.Type.DEFAULT);
+    }
+
+    public LabelBehaviour(Labels.Type type) {
+        this(Model.of(type));
+    }
+
+    public LabelBehaviour(IModel<Labels.Type> type) {
+        this.labelType = type;
+    }
+
+    public LabelBehaviour setType(Labels.Type type) {
+        this.labelType.setObject(type);
+        return this;
+    }
+
+    @Override
+    public void onComponentTag(Component component, ComponentTag tag) {
+        super.onComponentTag(component, tag);
+
+        Components.assertTag(component, tag, "span");
+        Labels.onComponentTag(component, tag, labelType.getObject());
+    }
+}

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/label/Labels.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/label/Labels.java
@@ -1,0 +1,67 @@
+package de.agilecoders.wicket.core.markup.html.bootstrap.label;
+
+import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
+import de.agilecoders.wicket.core.util.Attributes;
+import de.agilecoders.wicket.core.util.CssClassNames;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.util.lang.Args;
+
+/**
+ * Helper class that holds all special style modification
+ * types of a label.
+ *
+ * @author drummer
+ */
+public final class Labels {
+
+    /**
+     * private constructor to prevent instantiation
+     */
+    private Labels() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Defines all possible label styles.
+     * <a href="https://getbootstrap.com/docs/3.3/components/#labels"></a>
+     */
+    public enum Type implements ICssClassNameProvider {
+        DEFAULT("label-default"),
+        PRIMARY("label-primary"),
+        SUCCESS("label-success"),
+        WARNING("label-warning"),
+        INFO("label-info"),
+        DANGER("label-danger");
+
+        private final String cssClassName;
+
+        Type(final String cssClassName) {
+            this.cssClassName = cssClassName;
+        }
+
+        @Override
+        public String cssClassName() {
+            return cssClassName;
+        }
+    }
+
+    /**
+     * helper method that adds all necessary css styles to given component tag.
+     *
+     * @param component          the component to which given tag belongs, needed because of enabled state
+     * @param tag                the component tag
+     * @param classNameProviders all css class names to add
+     */
+    public static void onComponentTag(final Component component, final ComponentTag tag, final ICssClassNameProvider... classNameProviders) {
+        Args.notNull(classNameProviders, "classNameProviders");
+
+        final CssClassNames.Builder builder = CssClassNames.newBuilder().add("label");
+
+        for (final ICssClassNameProvider provider : classNameProviders) {
+            builder.add(provider.cssClassName());
+        }
+
+        Attributes.addClass(tag, builder.asString());
+    }
+}

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapChoiceFilteredPropertyColumn.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapChoiceFilteredPropertyColumn.java
@@ -1,0 +1,49 @@
+package de.agilecoders.wicket.extensions.markup.html.bootstrap.table.filter;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.ChoiceFilteredPropertyColumn;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm;
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.PropertyModel;
+
+import java.util.List;
+
+/**
+ * A bootstrap version of {@link ChoiceFilteredPropertyColumn}.
+ *
+ * @author drummer
+ */
+public class BootstrapChoiceFilteredPropertyColumn<T, Y, S> extends ChoiceFilteredPropertyColumn<T, Y, S> {
+
+    private String filterPropertyExpression;
+
+    public BootstrapChoiceFilteredPropertyColumn(final IModel<String> displayModel, final S sortProperty, final String propertyExpression,
+                                                 final IModel<? extends List<? extends Y>> filterChoices, final String filterPropertyExpression) {
+        super(displayModel, sortProperty, propertyExpression, filterChoices);
+        this.filterPropertyExpression = filterPropertyExpression;
+    }
+
+    public BootstrapChoiceFilteredPropertyColumn(final IModel<String> displayModel, final String propertyExpression,
+                                                 final IModel<? extends List<? extends Y>> filterChoices, final String filterPropertyExpression) {
+        super(displayModel, propertyExpression, filterChoices);
+        this.filterPropertyExpression = filterPropertyExpression;
+    }
+
+    @Override
+    public Component getFilter(final String componentId, final FilterForm<?> form) {
+
+        final BootstrapSelectFilter<Y> filter =
+            new BootstrapSelectFilter<>(componentId, getFilterModel(form), form, getFilterChoices(), enableAutoSubmit());
+        final IChoiceRenderer<Y> renderer = getChoiceRenderer();
+        if (renderer != null) {
+            filter.getChoice().setChoiceRenderer(renderer);
+        }
+        return filter;
+    }
+
+    @Override
+    protected IModel<Y> getFilterModel(final FilterForm<?> form) {
+        return new PropertyModel<>(form.getDefaultModel(), filterPropertyExpression);
+    }
+}

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapSelectFilter.html
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapSelectFilter.html
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<wicket:panel xmlns:wicket="http://wicket.apache.org"><select wicket:id="filter" class="form-control"></select></wicket:panel>

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapSelectFilter.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapSelectFilter.java
@@ -1,0 +1,116 @@
+package de.agilecoders.wicket.extensions.markup.html.bootstrap.table.filter;
+
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.AbstractFilter;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm;
+import org.apache.wicket.markup.html.form.ChoiceRenderer;
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import java.util.List;
+
+/**
+ * A filter that renders a bootstrap select. Clone of {@link org.apache.wicket.extensions.markup.html.repeater.data.table.filter.ChoiceFilter}.
+ *
+ * @author drummer
+ */
+public class BootstrapSelectFilter<T> extends AbstractFilter {
+
+    private final BootstrapSelect<T> choice;
+
+    /**
+     * Constructor.
+     *
+     * @param id         component id
+     * @param model      model for the drop down choice component
+     * @param form       filter form this component will be attached to
+     * @param choices    list of choices, see {@link DropDownChoice}
+     * @param autoSubmit if true this filter will submit the form on selection change
+     */
+    public BootstrapSelectFilter(final String id, final IModel<T> model, final FilterForm<?> form,
+                                 final IModel<? extends List<? extends T>> choices, final boolean autoSubmit) {
+        this(id, model, form, choices, new ChoiceRenderer<>(), autoSubmit);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param id         component id
+     * @param model      model for the drop down choice component
+     * @param form       filter form this component will be attached to
+     * @param choices    list of choices, see {@link DropDownChoice}
+     * @param autoSubmit if true this filter will submit the form on selection change
+     */
+    public BootstrapSelectFilter(final String id, final IModel<T> model, final FilterForm<?> form,
+                                 final List<? extends T> choices, final boolean autoSubmit) {
+        this(id, model, form, Model.ofList(choices), new ChoiceRenderer<>(), autoSubmit);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param id         component id
+     * @param model      model for the drop down choice component
+     * @param form       filter form this component will be attached to
+     * @param choices    list of choices, see {@link DropDownChoice}
+     * @param renderer   choice renderer, see {@link DropDownChoice}
+     * @param autoSubmit if true this filter will submit the form on selection change
+     */
+    public BootstrapSelectFilter(final String id, final IModel<T> model, final FilterForm<?> form,
+                                 final List<? extends T> choices, final IChoiceRenderer<? super T> renderer,
+                                 final boolean autoSubmit) {
+        this(id, model, form, Model.ofList(choices), renderer, autoSubmit);
+    }
+
+    /**
+     * @param id         component id
+     * @param model      model for the drop down choice component
+     * @param form       filter form this component will be attached to
+     * @param choices    list of choices, see {@link DropDownChoice}
+     * @param renderer   choice renderer, see {@link DropDownChoice}
+     * @param autoSubmit if true this filter will submit the form on selection change
+     * @see DropDownChoice
+     */
+    public BootstrapSelectFilter(final String id, final IModel<T> model, final FilterForm<?> form,
+                                 final IModel<? extends List<? extends T>> choices,
+                                 final IChoiceRenderer<? super T> renderer,
+                                 final boolean autoSubmit) {
+        super(id, form);
+
+        choice = newDropDownChoice("filter", model, choices, renderer);
+
+        if (autoSubmit) {
+            choice.add(AttributeModifier.replace("onchange", "this.form.submit();"));
+        }
+        enableFocusTracking(choice);
+
+        add(choice);
+    }
+
+    /**
+     * Factory method for the drop down choice component
+     *
+     * @param id       component id
+     * @param model    component model
+     * @param choices  choices model
+     * @param renderer choice renderer
+     * @return created drop down component
+     */
+    protected BootstrapSelect<T> newDropDownChoice(final String id, final IModel<T> model,
+                                                   final IModel<? extends List<? extends T>> choices, final IChoiceRenderer<? super T> renderer) {
+        BootstrapSelect<T> dropDownChoice = new BootstrapSelect<>(id, model, choices, renderer);
+        dropDownChoice.setNullValid(true);
+        return dropDownChoice;
+    }
+
+    /**
+     * @return the DropDownChoice form component created to represent this filter
+     */
+    public final BootstrapSelect<T> getChoice() {
+        return choice;
+    }
+
+}

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapTextFilteredPropertyColumn.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapTextFilteredPropertyColumn.java
@@ -1,0 +1,43 @@
+package de.agilecoders.wicket.extensions.markup.html.bootstrap.table.filter;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.TextFilter;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.TextFilteredPropertyColumn;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.PropertyModel;
+
+/**
+ * A bootstrap version of {@link TextFilteredPropertyColumn}.
+ *
+ * @author drummer
+ */
+public class BootstrapTextFilteredPropertyColumn<T, F, S> extends TextFilteredPropertyColumn<T, F, S> {
+
+    private String filterPropertyExpression;
+
+    public BootstrapTextFilteredPropertyColumn(final IModel<String> displayModel, final S sortProperty, final String propertyExpression,
+                                               final String filterPropertyExpression) {
+        super(displayModel, sortProperty, propertyExpression);
+        this.filterPropertyExpression = filterPropertyExpression;
+    }
+
+    public BootstrapTextFilteredPropertyColumn(final IModel<String> displayModel, final String propertyExpression,
+                                               final String filterPropertyExpression) {
+        super(displayModel, propertyExpression);
+        this.filterPropertyExpression = filterPropertyExpression;
+    }
+
+    @Override
+    public Component getFilter(final String componentId, final FilterForm<?> form) {
+        final TextFilter textFilter = (TextFilter) super.getFilter(componentId, form);
+        textFilter.getFilter().add(new AttributeAppender("class", "form-control").setSeparator(" "));
+        return textFilter;
+    }
+
+    @Override
+    protected IModel<F> getFilterModel(final FilterForm<?> form) {
+        return new PropertyModel(form.getDefaultModel(), filterPropertyExpression);
+    }
+}

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/dataprovider/ExampleFilterSortDataProvider.java
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/dataprovider/ExampleFilterSortDataProvider.java
@@ -1,0 +1,203 @@
+package de.agilecoders.wicket.samples.dataprovider;
+
+import de.agilecoders.wicket.samples.dataprovider.ExampleFilterSortDataProvider.ExampleFilter;
+import de.agilecoders.wicket.samples.dataprovider.ExampleFilterSortDataProvider.ExampleFilterSortRowItem;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilterStateLocator;
+import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
+import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A dataprovider to show filtering and sorting. Note that this implementation is not optimal for production use.
+ *
+ * @author drummer on 23.04.2018.
+ */
+public class ExampleFilterSortDataProvider extends SortableDataProvider<ExampleFilterSortRowItem, String> implements IFilterStateLocator<ExampleFilter> {
+
+    private static final List<String> possibleLastNames = Arrays.asList("Meier", "Meyer", "Maier", "Müller", "Schulze", "Schmidt");
+    private static final List<String> possibleFirstNames = Arrays.asList("Horst", "Klaus", "Gert", "Frank", "Hermann", "Sven", "Stefan");
+
+    private List<ExampleFilterSortRowItem> allRowItems;
+    private List<ExampleFilterSortRowItem> filteredRowItems;
+
+    private ExampleFilter filterState = new ExampleFilter();
+
+    public ExampleFilterSortDataProvider() {
+
+        allRowItems = createTestData();
+        filteredRowItems = allRowItems;
+    }
+
+    @Override
+    public ExampleFilter getFilterState() {
+        return filterState;
+    }
+
+    @Override
+    public void setFilterState(ExampleFilter exampleFilter) {
+        this.filterState = exampleFilter;
+    }
+
+    @Override
+    public Iterator<? extends ExampleFilterSortRowItem> iterator(long first, long count) {
+
+        int from = (int) first;
+        int to = (int) (first + count);
+        if (to > filteredRowItems.size()) {
+            to = filteredRowItems.size();
+        }
+
+        SortParam<String> sortParam = getSort();
+        if (sortParam != null) {
+            filteredRowItems.sort(getComparator(sortParam));
+        }
+
+        return filteredRowItems.subList(from, to).iterator();
+    }
+
+    @Override
+    public long size() {
+        doFilter(); // do filtering in size method because this is called before the iterator method.
+        return filteredRowItems == null ? 0 : filteredRowItems.size();
+    }
+
+    @Override
+    public IModel<ExampleFilterSortRowItem> model(ExampleFilterSortRowItem object) {
+        return Model.of(object);
+    }
+
+    private Comparator<ExampleFilterSortRowItem> getComparator(final SortParam<String> sortParam) {
+        Comparator<ExampleFilterSortRowItem> comparator;
+        if (ExampleFilterSortRowItem.SORTPARAM_FIRST_NAME.equals(sortParam.getProperty())) {
+            comparator = Comparator.nullsFirst(Comparator.comparing(item -> item.firstName));
+        } else if (ExampleFilterSortRowItem.SORTPARAM_LAST_NAME.equals(sortParam.getProperty())) {
+            comparator = Comparator.nullsFirst(Comparator.comparing(item -> item.lastName));
+        } else if (ExampleFilterSortRowItem.SORTPARAM_GENDER.equals(sortParam.getProperty())) {
+            comparator = Comparator.nullsFirst(Comparator.comparing(item -> item.gender));
+        } else {
+            throw new IllegalStateException("The sort param " + sortParam.getProperty() + " is not yet supprted");
+        }
+        if (!sortParam.isAscending()) {
+            comparator = comparator.reversed();
+        }
+
+        return comparator;
+    }
+
+    private void doFilter() {
+        filteredRowItems = allRowItems;
+        if (filterState != null) {
+            if (checkPropNotEmpty(filterState.firstName)) {
+                filteredRowItems = filteredRowItems.stream()
+                    .filter(f -> f.firstName != null)
+                    .filter(f -> f.firstName.contains(filterState.firstName))
+                    .collect(Collectors.toList());
+            }
+            if (checkPropNotEmpty(filterState.lastName)) {
+                filteredRowItems = filteredRowItems.stream()
+                    .filter(f -> f.lastName != null)
+                    .filter(f -> f.lastName.contains(filterState.lastName))
+                    .collect(Collectors.toList());
+            }
+            if (filterState.genderType != null) {
+                filteredRowItems = filteredRowItems.stream()
+                    .filter(f -> f.gender != null)
+                    .filter(f -> f.gender == filterState.genderType)
+                    .collect(Collectors.toList());
+            }
+        }
+    }
+
+    private List<ExampleFilterSortRowItem> createTestData() {
+
+        final List<ExampleFilterSortRowItem> rowItems = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            ExampleFilterSortRowItem rowItem = new ExampleFilterSortRowItem();
+            rowItem.firstName = getRandomFirstName();
+            rowItem.lastName = getRandomLastName();
+            // we only have two genders here because of ease in testData generation.
+            rowItem.gender = i % 2 == 0 ? GenderType.MALE : GenderType.FEMALE;
+
+            rowItems.add(rowItem);
+        }
+        return rowItems;
+    }
+
+    private String getRandomLastName() {
+        final Random random = new Random();
+        final int index = random.nextInt(possibleLastNames.size());
+        return possibleLastNames.get(index);
+    }
+
+    private String getRandomFirstName() {
+        final Random random = new Random();
+        final int index = random.nextInt(possibleFirstNames.size());
+        return possibleFirstNames.get(index);
+    }
+
+    private boolean checkPropNotEmpty(final String propertyValue) {
+        return (propertyValue != null && !propertyValue.isEmpty());
+    }
+
+    /**
+     * Lets assume that the row items holds informations about a person. The gender of that person is represented by an enumeration.
+     */
+    public static class ExampleFilterSortRowItem implements Serializable {
+
+        public static final String PROPERTY_FIRST_NAME = "firstName";
+        public static final String PROPERTY_LAST_NAME = "lastName";
+        public static final String PROPERTY_GENDER = "gender";
+
+        public static final String SORTPARAM_FIRST_NAME = "firstNameSortParam";
+        public static final String SORTPARAM_LAST_NAME = "lastNameSortParam";
+        public static final String SORTPARAM_GENDER = "genderSortParam";
+
+        public String firstName;
+        public String lastName;
+        public GenderType gender;
+
+        @Override
+        public final String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+    }
+
+    public static class ExampleFilter implements Serializable {
+
+        // the constants muss have the same value as the referenced property is named.
+        public static final String FILTER_FIRST_NAME = "firstName";
+        public static final String FILTER_LAST_NAME = "lastName";
+        public static final String FILTER_GENDER_TYPE = "genderType";
+
+        public String firstName;
+        public String lastName;
+        public GenderType genderType;
+
+        @Override
+        public final String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+    }
+
+    public enum GenderType {
+
+        MALE("male"),
+        FEMALE("female");
+
+        private final String displayValue;
+
+        GenderType(final String displayValue) {
+            this.displayValue = displayValue;
+        }
+
+        public String getDisplayValue() {
+            return displayValue;
+        }
+    }
+}

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/BasePage.java
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/BasePage.java
@@ -112,7 +112,8 @@ abstract class BasePage extends GenericWebPage<Void> {
                                 .setLabel(Model.of("Github"))
                                 .setTarget(BootstrapExternalLink.Target.blank)
                                 .setIconType(GlyphIconType.export),
-                        newAddonsDropDownButton())
+                        newAddonsDropDownButton(),
+                        newExamplesDropDownButton())
         );
         navbar.addComponents(new NavbarText(navbar.newExtraItemId(), "Plain text").position(Navbar.ComponentPosition.RIGHT));
 
@@ -145,6 +146,19 @@ abstract class BasePage extends GenericWebPage<Void> {
         navbar.addComponents(new ImmutableNavbarComponent(dropdown, Navbar.ComponentPosition.RIGHT));
 
         return navbar;
+    }
+
+    private Component newExamplesDropDownButton() {
+        return new NavbarDropDownButton(Model.of("Examples")) {
+            @Override
+            protected List<AbstractLink> newSubMenuButtons(String buttonMarkupId) {
+                final List<AbstractLink> subMenu = new ArrayList<>();
+
+                subMenu.add(new MenuBookmarkablePageLink<Void>(DataTablePage.class, Model.of("DataTable")));
+
+                return subMenu;
+            }
+        };
     }
 
     /**

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.html
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.html
@@ -1571,7 +1571,7 @@
         <tbody>
             <tr>
                 <td>
-                    <span class="label label-default">Default</span>
+                    <span wicket:id="defaultLabel">[Default]</span>
                 </td>
                 <td>
                     <code>&lt;span class="label"&gt;Default&lt;/span&gt;</code>
@@ -1579,7 +1579,7 @@
             </tr>
             <tr>
                 <td>
-                    <span class="label label-primary">Primary</span>
+                    <span wicket:id="primaryLabel">[Primary]</span>
                 </td>
                 <td>
                     <code>&lt;span class="label label-primary"&gt;Primary&lt;/span&gt;</code>
@@ -1587,7 +1587,7 @@
             </tr>
             <tr>
                 <td>
-                    <span class="label label-success">Success</span>
+                    <span wicket:id="successLabel">[Success]</span>
                 </td>
                 <td>
                     <code>&lt;span class="label label-success"&gt;Success&lt;/span&gt;</code>
@@ -1595,7 +1595,7 @@
             </tr>
             <tr>
                 <td>
-                    <span class="label label-warning">Warning</span>
+                    <span wicket:id="warningLabel">[Warning]</span>
                 </td>
                 <td>
                     <code>&lt;span class="label label-warning"&gt;Warning&lt;/span&gt;</code>
@@ -1603,7 +1603,7 @@
             </tr>
             <tr>
                 <td>
-                    <span class="label label-info">Info</span>
+                    <span wicket:id="infoLabel">[Info]</span>
                 </td>
                 <td>
                     <code>&lt;span class="label label-info"&gt;Info&lt;/span&gt;</code>
@@ -1611,7 +1611,7 @@
             </tr>
             <tr>
                 <td>
-                    <span class="label label-danger">Danger</span>
+                    <span wicket:id="dangerLabel">[Danger]</span>
                 </td>
                 <td>
                     <code>&lt;span class="label label-danger"&gt;Danger&lt;/span&gt;</code>

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.java
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.java
@@ -13,6 +13,8 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.form.radio.AjaxBootstrap
 import de.agilecoders.wicket.core.markup.html.bootstrap.form.radio.BooleanRadioGroup;
 import de.agilecoders.wicket.core.markup.html.bootstrap.form.radio.EnumRadioChoiceRenderer;
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
+import de.agilecoders.wicket.core.markup.html.bootstrap.label.BootstrapLabel;
+import de.agilecoders.wicket.core.markup.html.bootstrap.label.Labels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.tabs.AjaxBootstrapTabbedPanel;
 import de.agilecoders.wicket.core.markup.html.bootstrap.tabs.ClientSideBootstrapTabbedPanel;
 import de.agilecoders.wicket.samples.components.basecss.ButtonGroups;
@@ -66,6 +68,9 @@ public class ComponentsPage extends BasePage {
 
         // create radio buttons
         addRadioGroups();
+
+        // create bootstrap labels
+        addLabels();
 
         // add example for dropdown button with sub-menu
 //        add(newDropDownSubMenuExample());
@@ -161,6 +166,15 @@ public class ComponentsPage extends BasePage {
         enumAjax.setDefaultModel(enumAjaxSelectedModel);
         enumAjax.setChoiceRenderer(new EnumRadioChoiceRenderer<Status>(Buttons.Type.Success, enumAjax));
         add(enumAjax);
+    }
+
+    private void addLabels() {
+        add(new BootstrapLabel("defaultLabel", Model.of("Default"), Labels.Type.DEFAULT));
+        add(new BootstrapLabel("primaryLabel", Model.of("Primary"), Labels.Type.PRIMARY));
+        add(new BootstrapLabel("successLabel", Model.of("Success"), Labels.Type.SUCCESS));
+        add(new BootstrapLabel("warningLabel", Model.of("Warning"), Labels.Type.WARNING));
+        add(new BootstrapLabel("infoLabel", Model.of("Info"), Labels.Type.INFO));
+        add(new BootstrapLabel("dangerLabel", Model.of("Danger"), Labels.Type.DANGER));
     }
 
     private Component newTabs(String markupId) {

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/DataTablePage.html
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/DataTablePage.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<head>
+    <meta charset="utf-8"/>
+    <title>DataTablePage</title>
+</head>
+<body>
+<wicket:extend>
+    <header class="jumbotron subhead" id="overview">
+        <div class="container">
+            <h1>Datatable Examples</h1>
+            <p class="lead">Some Examples with Datatables.</p>
+        </div>
+    </header>
+
+    <div class="container">
+        <form wicket:id="filterForm">
+            <table wicket:id="dataTable"></table>
+        </form>
+    </div>
+</wicket:extend>
+</body>
+</html>

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/DataTablePage.java
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/DataTablePage.java
@@ -1,0 +1,106 @@
+package de.agilecoders.wicket.samples.pages;
+
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.table.BootstrapDefaultDataTable;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.table.filter.BootstrapChoiceFilteredPropertyColumn;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.table.filter.BootstrapSelectFilter;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.table.filter.BootstrapTextFilteredPropertyColumn;
+import de.agilecoders.wicket.samples.dataprovider.ExampleFilterSortDataProvider;
+import de.agilecoders.wicket.samples.dataprovider.ExampleFilterSortDataProvider.ExampleFilter;
+import de.agilecoders.wicket.samples.dataprovider.ExampleFilterSortDataProvider.ExampleFilterSortRowItem;
+import de.agilecoders.wicket.samples.dataprovider.ExampleFilterSortDataProvider.GenderType;
+import org.apache.wicket.Component;
+import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterToolbar;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.ChoiceRenderer;
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.markup.repeater.Item;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.wicketstuff.annotation.mount.MountPath;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A page to show the use of bootstrap datatables.
+ *
+ * @author drummer
+ */
+@MountPath(value = "/datatable")
+public class DataTablePage extends BasePage {
+
+    private static final int ROWS_PER_PAGE = 10;
+
+    /**
+     * Construct.
+     *
+     * @param parameters current page parameters
+     */
+    public DataTablePage(PageParameters parameters) {
+        super(parameters);
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+
+        ExampleFilterSortDataProvider dataProvider = new ExampleFilterSortDataProvider();
+        final BootstrapDefaultDataTable dataTable = createDataTable(dataProvider);
+        final FilterForm<ExampleFilter> filterForm = new FilterForm<>("filterForm", dataProvider);
+        filterForm.add(dataTable);
+        dataTable.addTopToolbar(new FilterToolbar(dataTable, filterForm)); // makes the filters visible in top of every column
+        add(filterForm);
+    }
+
+    private BootstrapDefaultDataTable<ExampleFilterSortRowItem, String> createDataTable(final ExampleFilterSortDataProvider dataProvider) {
+        return new BootstrapDefaultDataTable<>("dataTable", createColumns(), dataProvider, ROWS_PER_PAGE).striped().bordered().condensed();
+    }
+
+    private List<IColumn<ExampleFilterSortRowItem, String>> createColumns() {
+
+        final List<IColumn<ExampleFilterSortRowItem, String>> columns = new ArrayList<>();
+
+        columns.add(new BootstrapTextFilteredPropertyColumn<>(Model.of("First Name"), ExampleFilterSortRowItem.SORTPARAM_FIRST_NAME,
+            ExampleFilterSortRowItem.PROPERTY_FIRST_NAME, ExampleFilter.FILTER_FIRST_NAME));
+        columns.add(new BootstrapTextFilteredPropertyColumn<>(Model.of("Last Name"), ExampleFilterSortRowItem.SORTPARAM_LAST_NAME,
+            ExampleFilterSortRowItem.PROPERTY_LAST_NAME, ExampleFilter.FILTER_LAST_NAME));
+        columns.add(new BootstrapChoiceFilteredPropertyColumn<ExampleFilterSortRowItem, GenderType, String>(Model.of("Gender"),
+            ExampleFilterSortRowItem.PROPERTY_GENDER, ExampleFilterSortRowItem.SORTPARAM_GENDER,
+            Model.ofList(Arrays.asList(GenderType.values())), ExampleFilter.FILTER_GENDER_TYPE) {
+
+            @Override
+            public void populateItem(Item<ICellPopulator<ExampleFilterSortRowItem>> item, String componentId, IModel<ExampleFilterSortRowItem> rowModel) {
+                item.add(new Label(componentId, Model.of(rowModel.getObject().gender.getDisplayValue())));
+            }
+
+            @Override
+            protected IChoiceRenderer<GenderType> getChoiceRenderer() {
+                return new ChoiceRenderer<GenderType>() {
+
+                    @Override
+                    public Object getDisplayValue(GenderType object) {
+                        return object.getDisplayValue();
+                    }
+                };
+            }
+
+            @Override
+            public Component getFilter(String componentId, FilterForm<?> form) {
+                final Component component = super.getFilter(componentId, form);
+                if (component instanceof BootstrapSelectFilter) {
+                    final BootstrapSelectFilter selectFilter = (BootstrapSelectFilter) component;
+                    // change none selected to an empty string
+                    selectFilter.getChoice().config().withNoneSelectedText("");
+                }
+                return component;
+            }
+        });
+
+        return columns;
+    }
+}


### PR DESCRIPTION
Added a Bootstrap Label Component (https://getbootstrap.com/docs/3.3/components/#labels). Its implementation is done analog to the BootstrapButton´s implementation. 
Added a BootstrapTextFilteredPropertyColumn and a BootstrapChoiceFilteredPropertyColumn to be used with the BootstrapDefaultDataTable. I Also added a filtered datatable example linked in a separate "example" nav dropdown for the demo application. If this example is not wanted in the demo application I will remove it. I thought it would not be right placed in the "BaseCSS" or "Components" section so I added an example navigation dropdown.

The Datatable example looks like this.
![datatableexamplepage](https://user-images.githubusercontent.com/5657636/39375800-de7923a6-4a4f-11e8-9824-6cebbe3e660d.PNG)

