### PR TITLE
Fix warning: FileinputCssReference 'img/loading.gif' cannot be located

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/res/fileinput.css
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/res/fileinput.css
@@ -16,7 +16,7 @@
     font-size: 999px;
     text-align: right;
     color: #fff;
-    background: transparent url('../img/loading.gif') top left no-repeat;
+    background: transparent url('../res/loading.gif') top left no-repeat;
     border: none;
 }
 
@@ -182,7 +182,7 @@
 }
 
 .file-thumb-loading {
-    background: transparent url('../img/loading.gif') no-repeat scroll center center content-box !important;
+    background: transparent url('../res/loading.gif') no-repeat scroll center center content-box !important;
 }
 
 .file-actions {
@@ -267,7 +267,7 @@
 }
 
 .file-uploading {
-    background: url('../img/loading-sm.gif') no-repeat center bottom 10px;
+    background: url('../res/loading-sm.gif') no-repeat center bottom 10px;
     opacity: 0.65;
 }
 


### PR DESCRIPTION
Steps to reproduce:

1. open: extensions/BootstrapFileInput
2. open: Dev console or wicket sever log
3. click: Browse and select an image

Dev console shows: _Failed to load resource: the server responded with a status of 404 (Not Found)_