### PR TITLE
Add load imports from jar scheme in url importer

### DIFF
--- a/bootstrap-sass/src/test/java/de/agilecoders/wicket/sass/BootstrapSassTest.java
+++ b/bootstrap-sass/src/test/java/de/agilecoders/wicket/sass/BootstrapSassTest.java
@@ -72,8 +72,9 @@ public class BootstrapSassTest {
 
     /**
      * Tests with {@link ContextRelativeSassResourceReference}
-     *
+     * <p>
      * https://github.com/l0rdn1kk0n/wicket-bootstrap/issues/524
+     *
      * @throws Exception
      */
     @Test
@@ -131,6 +132,17 @@ public class BootstrapSassTest {
         String css = sass.getCss(sassSource);
         assertThat(css, containsString("root-cls"));
         assertThat(css, containsString("partial"));
+    }
+
+    @Test
+    public void importLocalJarPath() {
+        // test case for issue #794
+        SassCacheManager sass = SassCacheManager.get();
+        URL res = Thread.currentThread().getContextClassLoader().getResource("importRelativeLocalPath.scss");
+
+        SassSource sassSource = sass.getSassContext(res, null);
+        String css = sass.getCss(sassSource);
+        assertThat(css, containsString("* Bootstrap"));
     }
 
     @Test

--- a/bootstrap-sass/src/test/resources/importRelativeLocalPath.scss
+++ b/bootstrap-sass/src/test/resources/importRelativeLocalPath.scss
@@ -1,0 +1,2 @@
+
+@import "webjars!bootstrap/current/scss/bootstrap.scss"


### PR DESCRIPTION
Fixes #794 

UrlImporter tried to load resources in `jar:file/.../bootstrap-4.1.2.jar!/../_function.scss` using File API which doesn't work for classpath resources. I added classpath loading if absolute resource path contains `jar!`.