### PR TITLE
Bugfix/closure compiler and conflicts due to shaded gson-2.7

### DIFF
--- a/bootstrap-extensions/pom.xml
+++ b/bootstrap-extensions/pom.xml
@@ -70,7 +70,7 @@
 
         <dependency>
             <groupId>com.google.javascript</groupId>
-            <artifactId>closure-compiler</artifactId>
+            <artifactId>closure-compiler-unshaded</artifactId>
             <version>${google-closure.version}</version>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
google closure-compiler beyond `v20140814` contains a shaded version of `gson` version 2.7.

Using `wicket-bootstrap-2.0.8` in my current spring-boot-2 project fails, as spring-boot-starter-parent pulls in `gson-2.8.5`, which has a conflicting api with version 2.7. As 2.7 is not pulled in as (transitive) dependency (but in shaded form), the maven dependency resulution mechanism is unable to resolve the conflict by selecting one version over the other.

Google does not give the upgrade of gson as dependency of closure-compiler (or any other google projects) high priority (see [this](https://github.com/google/closure-compiler/issues/2815), but they provide an unshaded version of closure-compiler. This allows the maven dependency management to kick in properly.

This PR switches to `closure-compiler-unshaded` in the bootstrap-extensions maven module. This restores the functionality in e.g. my project. In the mean time excluding closure-compiler from wicket-boostrap in projects using wicket-bootstrap and explicitly depending on the unshaded version is a valid workaround. This could be reverted once and if this PR will be merged and wicket-boostrap released.

The automated tests in bootstrap-extensions pass but I did not smoke test any additional functionality within wicket-bootstrap.

Thanks and cheers
Urs