### PR TITLE
Move panel's content initialization to the onInitialize method.

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/panel/BootstrapGenericPanel.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/panel/BootstrapGenericPanel.java
@@ -69,7 +69,13 @@ public class BootstrapGenericPanel<T> extends GenericPanel<T>{
 		this.titleModel = panelTitleModel;
 		
 		add(this.panelBehavior = new PanelBehavior(panelType));
-		
+	}
+	
+	@Override
+	protected void onInitialize()
+	{
+		super.onInitialize();
+
 		//Panel Title
 		Label panelTitle = newTitleLabel(_PANEL_TITLE_ID, getModel(), getTitleModel());
 		add(panelTitle);
@@ -85,7 +91,6 @@ public class BootstrapGenericPanel<T> extends GenericPanel<T>{
 		Panel panelFooter = newFooterPanel(_PANEL_FOOTER_ID, getModel());
 		add(panelFooter);
 		Components.hideIfModelIsEmpty(panelFooter);
-		
 	}
 	
 	/**

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/panel/BootstrapGenericPanel.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/panel/BootstrapGenericPanel.java
@@ -5,6 +5,7 @@ import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameModifier;
 import de.agilecoders.wicket.core.util.Components;
@@ -146,7 +147,7 @@ public class BootstrapGenericPanel<T> extends GenericPanel<T>{
 	protected Panel newBodyPanel(String id, IModel<T> model){
 		
 		Panel emptyPanel = new EmptyPanel(id);
-		emptyPanel.setDefaultModel(null);
+		emptyPanel.setDefaultModel(new Model<>());
 		
 		return emptyPanel;
 
@@ -161,7 +162,7 @@ public class BootstrapGenericPanel<T> extends GenericPanel<T>{
 	protected Panel newFooterPanel(String id, IModel<T> model){
 		
 		Panel emptyPanel = new EmptyPanel(id);
-		emptyPanel.setDefaultModel(null);
+		emptyPanel.setDefaultModel(new Model<>());
 		
 		return emptyPanel;
 	}


### PR DESCRIPTION
Also instead of setting null model, pass empty model - this way when calling `Components.hideIfModelIsEmpty` upon panel's initialization, there is no hierarchy traversal that tries to get model's object value with the `panelFooter` and `panelBody` property lookups.