### PR TITLE
#852 - SassResourceReference does not work if SCSS files are in JARs

### DIFF
--- a/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/SassCacheManager.java
+++ b/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/SassCacheManager.java
@@ -144,14 +144,14 @@ public class SassCacheManager {
                             // one the file system, e.g. when it is loaded from a JAR.
                             // In this execution path, local imports are not supported, but they
                             // should usually be substitutable by package imports.
-                            String scssConcent;
+                            String scssContent;
                             try (InputStream is = sassSource.getURL().openStream()) {
-                                scssConcent = IOUtils.toString(is, StandardCharsets.UTF_8);
+                                scssContent = IOUtils.toString(is, StandardCharsets.UTF_8);
                             } catch (IOException e) {
                                 throw new WicketRuntimeException("Cannot read SASS resource "
                                         + sassSource.getURL().toExternalForm() + ". ", e);
                             }
-                            result = compiler.compileString(scssConcent, options);
+                            result = compiler.compileString(scssContent, options);
                         }
                         sassSource.addImportedSources(trackingImporter.getImportedSources());
                         cssContent = result.getCss();

--- a/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/UrlImporter.java
+++ b/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/UrlImporter.java
@@ -196,7 +196,9 @@ class UrlImporter implements Importer {
 
     private Optional<Import> resolveJarDependency(String url) {
         LOG.debug("Going to resolve an import from jar file: {}", url);
-        int jarSchemeIndex = url.indexOf(JAR_SCHEME);
+        // Using the last index here because in FAT JARs (e.g Spring Boot), there can be multiple
+        // nested JARs
+        int jarSchemeIndex = url.lastIndexOf(JAR_SCHEME);
         if (jarSchemeIndex == -1) {
             return Optional.empty();
         }


### PR DESCRIPTION
If the root SCSS resource is not on the file system, then load its content from its URL and compile it as a String. This is useful for compiling SCSS resources localed in JAR files. Local imports are not supported in such SCSS files, but they can usually be replaced with package imports.