### PR TITLE
[w9bs4] Bump wicket-webjars and wicket-jquery-selectors to 3.x versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
 
         <bootstrap.version>4.3.1</bootstrap.version>
         <config.version>0.3.5</config.version>
-        <wicket-webjars.version>2.0.16</wicket-webjars.version>
-        <wicket-jquery-selectors.version>2.0.7</wicket-jquery-selectors.version>
+        <wicket-webjars.version>3.0.0-M4</wicket-webjars.version>
+        <wicket-jquery-selectors.version>3.0.0-M4</wicket-jquery-selectors.version>
 
         <enforcer.disable>true</enforcer.disable>
         <pmd.disable>true</pmd.disable>


### PR DESCRIPTION
Just stumbled upon. The changes from 'wicket-9.x' (64107fed7c731047cca62ab5c9720668e6789826) didn't make it to 'wicket-9.x-bootstrap-4.x'.
