### PR TITLE
Remove button-related CSS classes from menu buttons

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehavior.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.BootstrapBaseBehavior;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
+import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.core.util.Components;
 import de.agilecoders.wicket.core.util.CssClassNames;
 
@@ -137,12 +138,14 @@ public class ButtonBehavior extends BootstrapBaseBehavior {
 
         Components.assertTag(component, tag, "a", "button", "input");
 
-        // a menu button has no css classes, inherits its styles from the menu
-//        if (!Buttons.Type.Menu.equals(getType())) {
+        // a menu button has no button-related css classes, inherits its styles from the menu
+        if (!Buttons.Type.Menu.equals(getType())) {
             Buttons.onComponentTag(component, tag,
                                    buttonSize.getObject(),
                                    buttonType.getObject(),
                                    blockProvider);
-//        }
+        } else {
+            Attributes.addClass(tag, buttonType.getObject());
+        }
     }
 }

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehaviorTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehaviorTest.java
@@ -39,6 +39,16 @@ class ButtonBehaviorTest extends WicketApplicationTest {
         }
     }
 
+    @Test
+    void testRenderMenuButtonWithoutBtnClass() {
+        AbstractLink link = newLink(id());
+        link.add(new ButtonBehavior(Buttons.Type.Menu));
+
+        TagTester tag = startComponentInPage(link, "<a wicket:id='" + id() + "'>Link</a>");
+
+        assertNotContainsCssClass(tag, "btn");
+    }
+
     private AbstractLink newLink(String id) {
         return new Link<Void>(id) {
             @Override


### PR DESCRIPTION
In response to https://github.com/l0rdn1kk0n/wicket-bootstrap/commit/7ef866513d96fa292470aac650f0a25f419849d3#r37496625

Menu buttons should not receive any button-related CSS classes (.btn etc)
but only the .nav-link class in order to not break layouts. For more
information see https://getbootstrap.com/docs/4.0/components/navs/