### PR TITLE
fix active state of tabs

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/AjaxBootstrapTabbedPanel.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/AjaxBootstrapTabbedPanel.java
@@ -35,16 +35,6 @@ public class AjaxBootstrapTabbedPanel<T extends ITab> extends BootstrapTabbedPan
 		setVersioned(false);
 	}
 
-    @Override
-    protected LoopItem newTabContainer(int tabIndex) {
-        final LoopItem tabContainer = super.newTabContainer(tabIndex);
-
-        // Remove the .active class added by Wicket from the wrapping <li>
-        tabContainer.add(new CssClassNameRemover("active"));
-
-        return tabContainer;
-    }
-
 	@Override
 	protected WebMarkupContainer newLink(final String linkId, final int index) {
 		return new AjaxFallbackLink<Void>(linkId) {

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/AjaxBootstrapTabbedPanel.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/AjaxBootstrapTabbedPanel.java
@@ -1,10 +1,13 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.tabs;
 
+import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameAppender;
+import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameRemover;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxFallbackLink;
 import org.apache.wicket.extensions.ajax.markup.html.tabs.AjaxTabbedPanel;
 import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.list.LoopItem;
 import org.apache.wicket.model.IModel;
 
 import java.util.List;
@@ -32,11 +35,33 @@ public class AjaxBootstrapTabbedPanel<T extends ITab> extends BootstrapTabbedPan
 		setVersioned(false);
 	}
 
+    @Override
+    protected LoopItem newTabContainer(int tabIndex) {
+        final LoopItem tabContainer = super.newTabContainer(tabIndex);
+
+        // Remove the .active class added by Wicket from the wrapping <li>
+        tabContainer.add(new CssClassNameRemover("active"));
+
+        return tabContainer;
+    }
+
 	@Override
 	protected WebMarkupContainer newLink(final String linkId, final int index) {
 		return new AjaxFallbackLink<Void>(linkId) {
 
 			private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void onConfigure() {
+                super.onConfigure();
+
+                final int currentlyActiveTab = AjaxBootstrapTabbedPanel.this.getSelectedTab();
+
+                if (index == currentlyActiveTab) {
+                    // Add the .active class to the <a>
+                    add(new CssClassNameAppender("active"));
+                }
+            }
 
 			@Override
 			public void onClick(final Optional<AjaxRequestTarget> targetOptional) {


### PR DESCRIPTION
In Bootstrap 4, active tabs need the .active class on the \<a>-Tag
instead of the \<li>-Tag (This seems to be Wicket's default behavior).
This commit removes the .active class from the \<li>-Tag and adds it
to the \<a>-tag in order to fix the styling of active tabs.

For more information, see https://getbootstrap.com/docs/4.0/components/navs/#tabs