### PR TITLE
Remove .nav-link CSS class from Buttons.Type.Menu

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/Buttons.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/Buttons.java
@@ -89,7 +89,7 @@ public final class Buttons {
     public enum Type implements ICssClassNameProvider {
         Default("btn-secondary"), // Alias for secondary. Kept for backwards compatibility.
         Secondary("btn-secondary"), // Standard gray button with gradient
-        Menu("nav-link"), // Menu button which has no default css class name
+        Menu(""), // Menu button which has no default css class name
         Primary("btn-primary"), // Provides extra visual weight and identifies the primary action in a set of buttons
         Info("btn-info"), // Used as an alternate to the default styles
         Success("btn-success"), // Indicates a successful or positive action

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonsTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonsTest.java
@@ -17,4 +17,9 @@ class ButtonsTest {
         assertThat(Buttons.Size.Medium.cssClassName(), is(""));
     }
 
+    @Test
+    void menuButtonHasNoCssClass() {
+        assertThat(Buttons.Type.Menu.cssClassName(), is(""));
+    }
+
 }


### PR DESCRIPTION
As discussed in #862:

The .nav-link CSS class is meant to be used for navigation menus, see https://getbootstrap.com/docs/4.0/components/navs/. It should not be used on arbitrary buttons because it adds a `display: block` style.