### PR TITLE
w9b4: Fix missing "nav-link" for Navbar links

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehavior.java
@@ -138,8 +138,8 @@ public class ButtonBehavior extends BootstrapBaseBehavior {
 
         Components.assertTag(component, tag, "a", "button", "input");
 
-        // a menu button has no button-related css classes, inherits its styles from the menu
-        if (!Buttons.Type.Menu.equals(getType())) {
+        // a menu button or nav link has no button-related CSS classes, inherits its styles from the menu
+        if (!Buttons.Type.Menu.equals(getType()) && !Buttons.Type.NavLink.equals(getType())) {
             Buttons.onComponentTag(component, tag,
                                    buttonSize.getObject(),
                                    buttonType.getObject(),

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/Buttons.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/Buttons.java
@@ -105,7 +105,8 @@ public final class Buttons {
         Outline_Warning("btn-outline-warning"),
         Outline_Info("btn-outline-info"),
         Outline_Light("btn-outline-light"),
-        Outline_Dark("btn-outline-dark");
+        Outline_Dark("btn-outline-dark"),
+        NavLink("nav-link"); // type for Navbar buttons and links
 
         private final String cssClassName;
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navbar/NavbarButton.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navbar/NavbarButton.java
@@ -29,7 +29,7 @@ public class NavbarButton<T> extends BootstrapBookmarkablePageLink<T> {
      * @param <P>        type of the page class
      */
     public <P extends Page> NavbarButton(final Class<P> pageClass, final PageParameters parameters, final IModel<String> label) {
-        super(Navbar.componentId(), pageClass, parameters, Buttons.Type.Menu);
+        super(Navbar.componentId(), pageClass, parameters, Buttons.Type.NavLink);
 
         setLabel(label);
     }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navbar/NavbarDropDownButton.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navbar/NavbarDropDownButton.java
@@ -1,15 +1,10 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.navbar;
 
-import java.util.List;
-
 import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.model.IModel;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameAppender;
-import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameRemover;
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.ButtonBehavior;
-import de.agilecoders.wicket.core.markup.html.bootstrap.button.ButtonList;
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.Buttons;
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.dropdown.DropDownButton;
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
@@ -66,23 +61,7 @@ public abstract class NavbarDropDownButton extends DropDownButton {
     @Override
     protected WebMarkupContainer newButton(String markupId, IModel<String> labelModel, final IModel<IconType> iconTypeModel) {
         WebMarkupContainer button = super.newButton(markupId, labelModel, iconTypeModel);
-        button.add(new CssClassNameRemover("btn"));
-        button.add(new CssClassNameAppender(Buttons.Type.Menu.cssClassName()));
+        button.add(new CssClassNameAppender(Buttons.Type.NavLink.cssClassName()));
         return button;
-    }
-
-    @Override
-    protected ButtonList newButtonList(String markupId) {
-        List<AbstractLink> buttons = newSubMenuButtons(ButtonList.getButtonMarkupId());
-        // we don't want nav-link classes in navbar dropdowns, because they inherit color from navbar-dark
-        // and result is white text on white background.
-        for (AbstractLink button : buttons) {
-            button.add(new CssClassNameRemover(Buttons.Type.Menu.cssClassName()));
-        }
-
-        ButtonList buttonList = new ButtonList(markupId, buttons);
-        buttonList.setRenderBodyOnly(true);
-
-        return buttonList;
     }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navbar/NavbarExternalLink.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/navbar/NavbarExternalLink.java
@@ -19,7 +19,7 @@ public class NavbarExternalLink extends BootstrapExternalLink {
      * @param href the link destination
      */
     public NavbarExternalLink(IModel<String> href) {
-        this(href, Buttons.Type.Menu);
+        this(href, Buttons.Type.NavLink);
     }
 
     /**

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/WicketApplication.java
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/WicketApplication.java
@@ -97,6 +97,7 @@ public class WicketApplication extends WebApplication {
     public void init() {
         super.init();
 
+        getCspSettings().blocking().disabled();
         getApplicationSettings().setUploadProgressUpdatesEnabled(true);
 
         // deactivate ajax debug mode

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.html
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.html
@@ -1016,8 +1016,8 @@ Need to stack them on some viewports but not others? Use the responsive versions
         <div class="collapse navbar-collapse">
             <ul class="navbar-nav">
                 <li class="nav-item"><a class="nav-link active" href="#">Home</a></li>
-                <li class="nav-item"><a href="#">Link</a></li>
-                <li class="nav-item"><a href="#">Link</a></li>
+                <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+                <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
             </ul>
         </div>
     </div>
@@ -1027,8 +1027,8 @@ Need to stack them on some viewports but not others? Use the responsive versions
   &lt;li class="nav-item"&gt;
     &lt;a class="nav-link active" href="#">Home&lt;/a&gt;
   &lt;/li&gt;
-  &lt;li class="nav-item&gt;&lt;a class="nav-link" href="#"&gt;Link&lt;/a&gt;&lt;/li&gt;
-  &lt;li class="nav-item&gt;&lt;a class="nav-link" href="#"&gt;Link&lt;/a&gt;&lt;/li&gt;
+  &lt;li class="nav-item"&gt;&lt;a class="nav-link" href="#"&gt;Link&lt;/a&gt;&lt;/li&gt;
+  &lt;li class="nav-item"&gt;&lt;a class="nav-link" href="#"&gt;Link&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;
 </pre>
 


### PR DESCRIPTION
This PR is based upon @solomax work in #867 with button-groups fixed.

The CSP fix for the samples application is a separate commit, so that the main fix could potentially be backported to w8b4.

Things look like this now:

![image](https://user-images.githubusercontent.com/1134031/90793514-19315e80-e30c-11ea-89a3-a20458efad49.png)

Fixes #866 