### PR TITLE
w9b4: Fix CSS for vertical button groups

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonGroup.java
@@ -81,7 +81,7 @@ public abstract class ButtonGroup extends Panel {
     protected void onComponentTag(ComponentTag tag) {
         super.onComponentTag(tag);
 
-        Attributes.addClass(tag, orientation.cssClassName(), "btn-group");
+        Attributes.addClass(tag, orientation.cssClassName());
 
         if (!Size.Default.equals(size)) {
             Attributes.addClass(tag, size.cssClassName());

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/Buttons.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/Buttons.java
@@ -78,7 +78,7 @@ public final class Buttons {
 
         @Override
         public String cssClassName() {
-            return equals(Horizontal) ? "" : "btn-group-" + name().toLowerCase();
+            return equals(Horizontal) ? "btn-group" : "btn-group-vertical";
         }
     }
 


### PR DESCRIPTION
Only up to Bootstrap 2.x "btn-group" and "btn-group-vertical"
where needed for vertical orientation. Since Bootstrap 3.x
only the latter is required.

https://getbootstrap.com/docs/4.4/components/button-group/#vertical-variation
https://getbootstrap.com/docs/3.4/components/#btn-groups-vertical
versus
https://getbootstrap.com/2.3.2/components.html#buttonGroups

Before: ![w9b4-vbg-before](https://user-images.githubusercontent.com/1134031/90951305-0a58c200-e45a-11ea-9428-73018fbf0b45.png) After: ![w9b4-vbg-after](https://user-images.githubusercontent.com/1134031/90951308-104ea300-e45a-11ea-8101-dc8ac2b46b6d.png)

Can likely be backported to w8b4 und w8b3. Haven't checked, though!