### PR TITLE
Fix FontAwesome5Graphic interface to have public access modifier

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5IconTypeBuilder.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5IconTypeBuilder.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class FontAwesome5IconTypeBuilder {
 
-    interface FontAwesome5Graphic {
+    public interface FontAwesome5Graphic {
         String getPrefix();
 
         String getIconName();


### PR DESCRIPTION
Hi @martin-g . While converting parts of a project using wicket-bootstrap to kotlin, I ran into this issue with the default access modifier for the interface `FontAwesome5Graphic`. If it is not too much effort, I would highly appreciate a release with this fix, if it is not too much of an effort... Thanks upfront.