### PR TITLE
Downgrade font-awesome from 5.15.1 to 5.15.0

### DIFF
--- a/bootstrap-extensions/pom.xml
+++ b/bootstrap-extensions/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>font-awesome</artifactId>
-            <version>5.15.1</version>
+            <version>5.15.0</version>
         </dependency>
 
         <dependency>

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5CDNCSSReference.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5CDNCSSReference.java
@@ -11,7 +11,7 @@ import org.apache.wicket.request.resource.UrlResourceReference;
  *  &lt;dependency&gt;<br/>
  *      &lt;groupId&gt;org.webjars&lt;/groupId&gt;<br/>
  *      &lt;artifactId&gt;font-awesome&lt;/artifactId&gt;<br/>
- *      &lt;version&gt;5.15.1&lt;/version&gt;<br/>
+ *      &lt;version&gt;5.15.0&lt;/version&gt;<br/>
  *  &lt;/dependency&gt;<br/>
  *
  * reference for font awesome 5.x css via CDN

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5CssReference.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5CssReference.java
@@ -10,7 +10,7 @@ import de.agilecoders.wicket.webjars.request.resource.WebjarsCssResourceReferenc
  *  &lt;dependency&gt;<br/>
  *      &lt;groupId&gt;org.webjars&lt;/groupId&gt;<br/>
  *      &lt;artifactId&gt;font-awesome&lt;/artifactId&gt;<br/>
- *      &lt;version&gt;5.15.1&lt;/version&gt;<br/>
+ *      &lt;version&gt;5.15.0&lt;/version&gt;<br/>
  *  &lt;/dependency&gt;<br/>
  *
  * reference for font awesome 5.x css

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5IconType.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5IconType.java
@@ -1137,8 +1137,6 @@ public class FontAwesome5IconType extends IconType {
     public static final FontAwesome5IconType venus_double_s = on(FontAwesome5Solid.venus_double).build();
     public static final FontAwesome5IconType venus_mars_s = on(FontAwesome5Solid.venus_mars).build();
     public static final FontAwesome5IconType venus_s = on(FontAwesome5Solid.venus).build();
-    public static final FontAwesome5IconType vest_patches_s = on(FontAwesome5Solid.vest_patches).build();
-    public static final FontAwesome5IconType vest_s = on(FontAwesome5Solid.vest).build();
     public static final FontAwesome5IconType vial_s = on(FontAwesome5Solid.vial).build();
     public static final FontAwesome5IconType vials_s = on(FontAwesome5Solid.vials).build();
     public static final FontAwesome5IconType video_s = on(FontAwesome5Solid.video).build();
@@ -1188,7 +1186,6 @@ public class FontAwesome5IconType extends IconType {
     public static final FontAwesome5IconType accusoft = on(FontAwesome5Brand.accusoft).build();
     public static final FontAwesome5IconType acquisitions_incorporated = on(FontAwesome5Brand.acquisitions_incorporated).build();
     public static final FontAwesome5IconType adn = on(FontAwesome5Brand.adn).build();
-    public static final FontAwesome5IconType adobe = on(FontAwesome5Brand.adobe).build();
     public static final FontAwesome5IconType adversal = on(FontAwesome5Brand.adversal).build();
     public static final FontAwesome5IconType affiliatetheme = on(FontAwesome5Brand.affiliatetheme).build();
     public static final FontAwesome5IconType airbnb = on(FontAwesome5Brand.airbnb).build();
@@ -1497,7 +1494,6 @@ public class FontAwesome5IconType extends IconType {
     public static final FontAwesome5IconType quora = on(FontAwesome5Brand.quora).build();
     public static final FontAwesome5IconType r_project = on(FontAwesome5Brand.r_project).build();
     public static final FontAwesome5IconType raspberry_pi = on(FontAwesome5Brand.raspberry_pi).build();
-    public static final FontAwesome5IconType ravelry = on(FontAwesome5Brand.ravelry).build();
     public static final FontAwesome5IconType react = on(FontAwesome5Brand.react).build();
     public static final FontAwesome5IconType reacteurope = on(FontAwesome5Brand.reacteurope).build();
     public static final FontAwesome5IconType readme = on(FontAwesome5Brand.readme).build();

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5IconTypeBuilder.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5IconTypeBuilder.java
@@ -144,7 +144,7 @@ public class FontAwesome5IconTypeBuilder {
         university, unlink, unlock, unlock_alt, upload, user, user_alt, user_alt_slash, user_astronaut, user_check,
         user_circle, user_clock, user_cog, user_edit, user_friends, user_graduate, user_injured, user_lock, user_md,
         user_minus, user_ninja, user_nurse, user_plus, user_secret, user_shield, user_slash, user_tag, user_tie,
-        user_times, users, users_cog, users_slash, utensil_spoon, utensils, vector_square, venus, vest_patches, vest, venus_double, venus_mars, vial,
+        user_times, users, users_cog, users_slash, utensil_spoon, utensils, vector_square, venus, venus_double, venus_mars, vial,
         vials, video, video_slash, virus, virus_slash, viruses, vihara, voicemail, volleyball_ball, volume_down, volume_mute, volume_off, volume_up, vote_yea,
         vr_cardboard, walking, wallet, warehouse, water, wave_square, weight, weight_hanging, wheelchair, wifi, wind, window_close,
         window_maximize, window_minimize, window_restore, wine_bottle, wine_glass, wine_glass_alt, won_sign, wrench,
@@ -198,7 +198,7 @@ public class FontAwesome5IconTypeBuilder {
      * All icons of style 'brand' available for free in Font Awesome.
      */
     public enum FontAwesome5Brand implements FontAwesome5Graphic {
-        _500px, accessible_icon, accusoft, acquisitions_incorporated, adn, adobe, adversal, affiliatetheme, airbnb, algolia,
+        _500px, accessible_icon, accusoft, acquisitions_incorporated, adn, adversal, affiliatetheme, airbnb, algolia,
         alipay, amazon, amazon_pay, amilia, android, angellist, angrycreative, angular, app_store, app_store_ios, apper,
         apple, apple_pay, artstation, asymmetrik, atlassian, audible, autoprefixer, avianex, aviato, aws, bandcamp, battle_net,
         behance, behance_square, bimobject, bitbucket, bitcoin, bity, black_tie, blackberry, blogger, blogger_b,
@@ -228,7 +228,7 @@ public class FontAwesome5IconTypeBuilder {
         odnoklassniki_square, old_republic, opencart, openid, opera, optin_monster, orcid, osi, page4, pagelines, palfed,
         patreon, paypal, penny_arcade, perbyte, periscope, phabricator, phoenix_framework, phoenix_squadron, php, pied_piper,
         pied_piper_alt, pied_piper_hat, pied_piper_pp, pied_piper_square, pinterest, pinterest_p, pinterest_square, playstation,
-        product_hunt, pushed, python, qq, quinscape, quora, r_project, raspberry_pi, ravelry, react, reacteurope,
+        product_hunt, pushed, python, qq, quinscape, quora, r_project, raspberry_pi, react, reacteurope,
         readme, rebel, red_river, reddit, reddit_alien, reddit_square, redhat, renren, replyd, researchgate, resolving,
         rev, rocketchat, rockrms, rust, safari, salesforce, sass, schlix, scribd, searchengin, sellcast, sellsy, servicestack,
         shirtsinbulk, shopify, shopware, simplybuilt, sistrix, sith, sketch, skyatlas, skype, slack, slack_hash, slideshare,


### PR DESCRIPTION
@martin-g Sorry, I did not catch 
- that font-awesome-5.15.1 is not on maven central (yet?)
- the icon adobe has been removed

This PR downgrades to 5.15.0 that is available on maven central and removes three icons that are only available in 5.15.1 + the adobe icon