### PR TITLE
Fixed SummernoteEditor to retain user input on form validation error.

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/editor/SummernoteEditor.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/editor/SummernoteEditor.java
@@ -114,10 +114,10 @@ public class SummernoteEditor extends FormComponent<String> {
             IOUtils.closeQuietly(summernoteTemplate);
         }
 
-        String modelObject = getInput();
-        if (!config.isAirMode() && !Strings.isEmpty(modelObject)) {
-            modelObject = NEW_LINE_PATTERN.matcher(modelObject).replaceAll("<br/>");
-            CharSequence safeModelObject = JavaScriptUtils.escapeQuotes(modelObject);
+        String value = getValue();
+        if (!config.isAirMode() && !Strings.isEmpty(value)) {
+            value = NEW_LINE_PATTERN.matcher(value).replaceAll("<br/>");
+            CharSequence safeModelObject = JavaScriptUtils.escapeQuotes(value);
             response.render(OnDomReadyHeaderItem.forScript(String.format("$('#%s').summernote('code', '%s')",
                                                                          getMarkupId(), safeModelObject)));
         }

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/editor/SummernoteEditor.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/editor/SummernoteEditor.java
@@ -114,7 +114,7 @@ public class SummernoteEditor extends FormComponent<String> {
             IOUtils.closeQuietly(summernoteTemplate);
         }
 
-        String modelObject = getModelObject();
+        String modelObject = getInput();
         if (!config.isAirMode() && !Strings.isEmpty(modelObject)) {
             modelObject = NEW_LINE_PATTERN.matcher(modelObject).replaceAll("<br/>");
             CharSequence safeModelObject = JavaScriptUtils.escapeQuotes(modelObject);


### PR DESCRIPTION
SummernoteEditor loses the users input when another field in the form get a validation error and the submitted value has not been pushed to the model. The FormComponent getValue() method will return the submitted value. For values to not be escaped by getValue() SummernoteEditor setEscapeModelStrings(false) must be called after construction.