### PR TITLE
fix sizing of form controls for Bootstrap 4

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
@@ -28,7 +28,7 @@ public class InputBehavior extends BootstrapBaseBehavior {
 
         @Override
         public String cssClassName() {
-            return this == Medium ? "" : "input-" + cssName;
+            return this == Medium ? "" : "form-control-" + cssName;
         }
 
     }


### PR DESCRIPTION
Hey guys,

thank you for your great work. 

I've discovered a little issue. CSS classes for resizing form components has been changed in Bootstrap 4: <https://getbootstrap.com/docs/4.5/components/forms/#sizing> - This pull requests adds the new CSS classes to the `InputBehavior` class.