### PR TITLE
fix sizing of form controls for Bootstrap 4

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
@@ -28,7 +28,7 @@ public class InputBehavior extends BootstrapBaseBehavior {
 
         @Override
         public String cssClassName() {
-            return this == Medium ? "" : "input-" + cssName;
+            return this == Medium ? "" : "form-control-" + cssName;
         }
 
     }

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehaviorTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehaviorTest.java
@@ -42,7 +42,7 @@ class InputBehaviorTest extends WicketApplicationTest {
         TagTester tagTester = tester().getTagById("input");
         String cssClass = tagTester.getAttribute("class");
         assertThat(cssClass, Matchers.containsString("form-control"));
-        assertThat(cssClass, Matchers.containsString("input-lg"));
+        assertThat(cssClass, Matchers.containsString("form-control-lg"));
     }
 
     @Test
@@ -55,7 +55,7 @@ class InputBehaviorTest extends WicketApplicationTest {
         TagTester tagTester = tester().getTagById("input");
         String cssClass = tagTester.getAttribute("class");
         assertThat(cssClass, Matchers.containsString("form-control"));
-        assertThat(cssClass, Matchers.containsString("input-sm"));
+        assertThat(cssClass, Matchers.containsString("form-control-sm"));
 
         assertThat(tester().getLastResponseAsString(), Matchers.containsString("<div class=\"col-lg-11\""));
         assertThat(tester().getLastResponseAsString(), Matchers.containsString("</div"));
@@ -70,7 +70,7 @@ class InputBehaviorTest extends WicketApplicationTest {
         TagTester tagTester = tester().getTagById("input");
         String cssClass = tagTester.getAttribute("class");
         assertThat(cssClass, Matchers.containsString("form-control"));
-        assertThat(cssClass, Matchers.not(Matchers.containsString("input-lg")));
+        assertThat(cssClass, Matchers.not(Matchers.containsString("form-control-lg")));
 
         assertThat(tester().getLastResponseAsString(), Matchers.containsString("<div class=\"col-10\""));
         assertThat(tester().getLastResponseAsString(), Matchers.containsString("</div"));


### PR DESCRIPTION
Hey guys,

thank you for your great work.

I've discovered a little issue. CSS classes for resizing form components has been changed in Bootstrap 4: https://getbootstrap.com/docs/4.5/components/forms/#sizing - This pull requests adds the new CSS classes to the `InputBehavior` class.

PS: I've accidentally created an earlier PR on the wrong branch. After realizing the mistake I've closed the earlier PR. This one should be correct and updates `wicket-9.x-bootstrap-4.x`.