### PR TITLE
remove sizing of form groups as it is not supported by Bootstrap 4

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
@@ -18,6 +18,8 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.util.string.Strings;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,6 +54,8 @@ public class FormGroup extends Border {
         }
 
     }
+
+    private static final Logger LOG = LoggerFactory.getLogger(FormGroup.class);
 
     private Component label;
     private Component help;
@@ -112,6 +116,7 @@ public class FormGroup extends Border {
      * {@link InputBehavior#size(InputBehavior.Size)} on the {@link FormComponent} instead.
      */
     public FormGroup size(final Size size) {
+        LOG.warn("Ignore form group resizing as it is not supported by Bootstrap 4.");
         return this;
     }
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
@@ -1,7 +1,6 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.form;
 
 import com.google.common.base.Function;
-import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.core.util.Components;
 import org.apache.wicket.AttributeModifier;
@@ -31,31 +30,11 @@ import java.util.List;
  */
 public class FormGroup extends Border {
 
-    /**
-     * Holder class for all possible form group sizes
-     */
-    public enum Size implements ICssClassNameProvider {
-        Small("sm"), Large("lg");
-
-        private final String cssName;
-
-        Size(String cssName) {
-            this.cssName = cssName;
-        }
-
-        @Override
-        public String cssClassName() {
-            return "form-group-" + cssName;
-        }
-
-    }
-
     private Component label;
     private Component help;
     private Component feedback;
     private String stateClassName;
     private boolean useFormComponentLabel = true;
-    private Size size;
     private final IModel<String> labelModel;
     private final IModel<String> helpModel;
 
@@ -98,17 +77,6 @@ public class FormGroup extends Border {
      */
     public FormGroup useFormComponentLabel(boolean value) {
         this.useFormComponentLabel = value;
-        return this;
-    }
-
-    /**
-     * sets the size of form-group
-     *
-     * @param size the size to use
-     * @return this instance for chaining
-     */
-    public FormGroup size(final Size size) {
-        this.size = size;
         return this;
     }
 
@@ -158,9 +126,6 @@ public class FormGroup extends Border {
 
         checkComponentTag(tag, "div");
         Attributes.addClass(tag, "form-group", stateClassName);
-        if (size != null) {
-            Attributes.addClass(tag, size.cssClassName());
-        }
     }
 
     @Override

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
@@ -1,6 +1,7 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.form;
 
 import com.google.common.base.Function;
+import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.core.util.Components;
 import org.apache.wicket.AttributeModifier;
@@ -29,6 +30,28 @@ import java.util.List;
  * @author miha
  */
 public class FormGroup extends Border {
+
+    /**
+     * Holder class for all possible form group sizes
+     *
+     * @deprecated Not supported by Bootstrap 4. Use {@link InputBehavior.Size}
+     * on the {@link FormComponent} instead.
+     */
+    public enum Size implements ICssClassNameProvider {
+        Small("sm"), Large("lg");
+
+        private final String cssName;
+
+        Size(String cssName) {
+            this.cssName = cssName;
+        }
+
+        @Override
+        public String cssClassName() {
+            return "form-group-" + cssName;
+        }
+
+    }
 
     private Component label;
     private Component help;
@@ -77,6 +100,18 @@ public class FormGroup extends Border {
      */
     public FormGroup useFormComponentLabel(boolean value) {
         this.useFormComponentLabel = value;
+        return this;
+    }
+
+    /**
+     * sets the size of form-group
+     *
+     * @param size the size to use
+     * @return this instance for chaining
+     * @deprecated Not supported by Bootstrap 4. Use
+     * {@link InputBehavior#size(InputBehavior.Size)} on the {@link FormComponent} instead.
+     */
+    public FormGroup size(final Size size) {
         return this;
     }
 

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroupTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroupTest.java
@@ -96,52 +96,6 @@ class FormGroupTest extends WicketApplicationTest {
     }
 
     @Test
-    void formGroupLarge() {
-
-        Model<FormData> model = Model.of(new FormData());
-        model.getObject();
-
-        Form<FormData> form = new Form<>("form", new CompoundPropertyModel<>(model));
-
-        FormGroup group = new FormGroup("formGroup");
-        group.size(FormGroup.Size.Large);
-        form.add(group);
-
-        TextField<String> input = new TextField<>("value");
-        input.setRequired(true);
-        group.add(input);
-
-        tester().startComponentInPage(
-                form,
-                Markup.of("<form wicket:id='form'><div wicket:id='formGroup'><input type='text' wicket:id='value'/></div></form>"));
-        TagTester formGroupTester = tester().getTagByWicketId("formGroup");
-        assertThat(formGroupTester.getAttribute("class"), containsString("form-group-lg"));
-    }
-
-    @Test
-    void formGroupSmall() {
-
-        Model<FormData> model = Model.of(new FormData());
-        model.getObject();
-
-        Form<FormData> form = new Form<>("form", new CompoundPropertyModel<>(model));
-
-        FormGroup group = new FormGroup("formGroup");
-        group.size(FormGroup.Size.Small);
-        form.add(group);
-
-        TextField<String> input = new TextField<>("value");
-        input.setRequired(true);
-        group.add(input);
-
-        tester().startComponentInPage(
-                form,
-                Markup.of("<form wicket:id='form'><div wicket:id='formGroup'><input type='text' wicket:id='value'/></div></form>"));
-        TagTester formGroupTester = tester().getTagByWicketId("formGroup");
-        assertThat(formGroupTester.getAttribute("class"), containsString("form-group-sm"));
-    }
-
-    @Test
     void formGroupSubmitValidation() {
 
         tester().getSession().setLocale(Locale.ENGLISH); // for the validation message


### PR DESCRIPTION
Hey guys,

Bootstrap 4 does not support sizing of Form Groups. The classes `form-group-sm` & `form-group-lg` are no more available in their CSS and its not available in their documentation anymore. Therefore this PR removes the corresponding code from the `FormGroup` class.

It might lead to compilation problems, if developers are still using `FormGroup.Size` in their application. Do you prefer using deprecation annotations instead of just removing this feature?