### PR TITLE
fix validation on form groups for Bootstrap 4

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.html
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.html
@@ -8,8 +8,8 @@
 
             <wicket:body/>
 
-            <p wicket:id="error" class="form-text"></p>
-            <p wicket:id="help" class="form-text">Supporting help text</p>
+            <div wicket:id="error">Validation message</div>
+            <div wicket:id="help" class="form-text">Supporting help text</div>
         </wicket:border>
     </body>
 </html>

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
@@ -1,6 +1,5 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.form;
 
-import com.google.common.base.Function;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.core.util.Components;
@@ -23,6 +22,7 @@ import org.apache.wicket.util.visit.IVisitor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Simple form control group that is able to show a label, help text and feedback

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
@@ -6,6 +6,7 @@ import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.core.util.Components;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.feedback.FeedbackMessages;
 import org.apache.wicket.markup.ComponentTag;
@@ -157,7 +158,7 @@ public class FormGroup extends Border {
         super.onComponentTag(tag);
 
         checkComponentTag(tag, "div");
-        Attributes.addClass(tag, "form-group", stateClassName);
+        Attributes.addClass(tag, "form-group");
         if (size != null) {
             Attributes.addClass(tag, size.cssClassName());
         }
@@ -170,6 +171,12 @@ public class FormGroup extends Border {
         this.label = newLabel("label", labelModel);
         this.help = newHelpLabel("help", helpModel);
         this.feedback = newFeedbackMessageContainer("error");
+        this.feedback.add(new AttributeAppender("class", new Model<String>(){
+            @Override
+            public String getObject() {
+                return stateClassName;
+            }
+        }, " "));
         addToBorder(this.label, this.help, this.feedback);
 
 
@@ -312,9 +319,9 @@ public class FormGroup extends Border {
             switch (message.getLevel()) {
                 case FeedbackMessage.FATAL:
                 case FeedbackMessage.ERROR:
-                case FeedbackMessage.WARNING: return "is-invalid";
+                case FeedbackMessage.WARNING: return "invalid-feedback";
                 case FeedbackMessage.INFO:
-                case FeedbackMessage.SUCCESS: return "is-valid";
+                case FeedbackMessage.SUCCESS: return "valid-feedback";
                 default: return "";
             }
         }

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroupTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroupTest.java
@@ -147,8 +147,6 @@ class FormGroupTest extends WicketApplicationTest {
         tester().getSession().setLocale(Locale.ENGLISH); // for the validation message
 
         Model<FormData> model = Model.of(new FormData());
-        model.getObject();
-
         Form<FormData> form = new Form<>("form", new CompoundPropertyModel<>(model));
 
         FormGroup group = new FormGroup("id");
@@ -166,15 +164,13 @@ class FormGroupTest extends WicketApplicationTest {
         formTester.submit();
 
         tester().assertLabel("form:id:error", "&#039;value&#039; is required.");
-        tester().assertContains("class=\"invalid-feedback\""); //assert error CSS class is present
+        tester().assertContains("class=\"invalid-feedback\""); //assert invalid-feedback CSS class is present
     }
 
     @Test
     void formGroupSubmitValidationSuccess() {
 
         Model<FormData> model = Model.of(new FormData("test"));
-        model.getObject();
-
         Form<FormData> form = new Form<>("form", new CompoundPropertyModel<>(model));
 
         FormGroup group = new FormGroup("id");
@@ -198,7 +194,7 @@ class FormGroupTest extends WicketApplicationTest {
         formTester.submit();
 
         tester().assertLabel("form:id:error", "Value is valid.");
-        tester().assertContains("class=\"valid-feedback\""); //assert error CSS class is present
+        tester().assertContains("class=\"valid-feedback\""); //assert valid-feedback CSS class is present
     }
 
     private static class FormData implements Serializable {

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroupTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroupTest.java
@@ -166,7 +166,39 @@ class FormGroupTest extends WicketApplicationTest {
         formTester.submit();
 
         tester().assertLabel("form:id:error", "&#039;value&#039; is required.");
-        tester().assertContains("class=\".*is-invalid.*\""); //assert error CSS class is present
+        tester().assertContains("class=\"invalid-feedback\""); //assert error CSS class is present
+    }
+
+    @Test
+    void formGroupSubmitValidationSuccess() {
+
+        Model<FormData> model = Model.of(new FormData("test"));
+        model.getObject();
+
+        Form<FormData> form = new Form<>("form", new CompoundPropertyModel<>(model));
+
+        FormGroup group = new FormGroup("id");
+        form.add(group);
+
+        TextField<String> input = new TextField<>("value") {
+            @Override
+            protected void onValid() {
+                super.onValid();
+                success("Value is valid.");
+            }
+        };
+        input.setRequired(true);
+        group.add(input);
+
+        tester().startComponentInPage(
+                form,
+                Markup.of("<form wicket:id='form'><div wicket:id='id'><input type='text' wicket:id='value'/></div></form>"));
+        FormTester formTester = tester().newFormTester("form", false);
+
+        formTester.submit();
+
+        tester().assertLabel("form:id:error", "Value is valid.");
+        tester().assertContains("class=\"valid-feedback\""); //assert error CSS class is present
     }
 
     private static class FormData implements Serializable {
@@ -176,5 +208,13 @@ class FormGroupTest extends WicketApplicationTest {
         @SuppressWarnings("unused")
         private String value;
 
+
+        private FormData() {
+            this(null);
+        }
+
+        private FormData(String value) {
+            this.value = value;
+        }
     }
 }


### PR DESCRIPTION
Bootstrap 4 does not support `is-valid` & `is-invalid` classes on form groups anymore. Instead `valid-feedback` & `invalid-feedback` classes are used on the feedback container (with `wicket:id="error"`). See <https://getbootstrap.com/docs/4.5/components/forms/#server-side>.

This PR 

- removes the `is-valid` & `is-invalid` classes from form groups.
- adds `valid-feedback` & `invalid-feedback` classes to the feedback container.
- removes the `form-text` class from the feedback container in `FormGroup.html` according to Bootstrap 4 documentation.
- replaces `<p>` elements for help text and feedback container with `<div>` according to Bootstrap 4 documentation.

There are no changes, that should break the existing Java API. Only in case a developer implements his own `FormGroup.FeedbackMessageToCssClassNameTransformer` class, it might lead to rendering issues as this class is now used for the feedback container instead of the form group itself.