### PR TITLE
add validation classes to form controls for Bootstrap 4

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
@@ -1,11 +1,17 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.form;
 
+import com.google.common.base.Function;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.BootstrapBaseBehavior;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.core.markup.html.bootstrap.layout.col.SpanType;
 import de.agilecoders.wicket.core.util.Attributes;
 import org.apache.wicket.Component;
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.feedback.FeedbackMessages;
 import org.apache.wicket.markup.ComponentTag;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * An {@link InputBehavior} controls the size of an input tag.
@@ -105,6 +111,11 @@ public class InputBehavior extends BootstrapBaseBehavior {
         }
 
         Attributes.addClass(tag, "form-control");
+
+        final FeedbackMessages messages = component.getFeedbackMessages();
+        if (!messages.isEmpty()) {
+            Attributes.addClass(tag, toClassName(getWorstMessage(messages)));
+        }
     }
 
     @Override
@@ -122,6 +133,72 @@ public class InputBehavior extends BootstrapBaseBehavior {
 
         if (columnSize != null ) {
             component.getResponse().write("</div>");
+        }
+    }
+
+    /**
+     * ordered list of all feedback message types.
+     */
+    private static final List<Integer> messageTypes = Arrays.asList(
+            FeedbackMessage.FATAL, FeedbackMessage.ERROR, FeedbackMessage.WARNING, FeedbackMessage.SUCCESS,
+            FeedbackMessage.INFO, FeedbackMessage.DEBUG, FeedbackMessage.UNDEFINED
+    );
+
+    /**
+     * @return new function that transforms a {@link FeedbackMessage} to a css class name
+     */
+    protected Function<FeedbackMessage, String> newFeedbackMessageToCssClassNameTransformer() {
+        return new FeedbackMessageToCssClassNameTransformer();
+    }
+
+    /**
+     * returns the worst message that is available.
+     *
+     * @param messages all current feedback messages
+     * @return worst possible message or null
+     */
+    private FeedbackMessage getWorstMessage(final FeedbackMessages messages) {
+        for (final Integer messageType : messageTypes) {
+            final FeedbackMessage ret = messages.first(messageType);
+
+            if (ret != null) {
+                return ret;
+            }
+        }
+
+        return messages.first();
+    }
+
+    /**
+     * transforms a given feedback message to its css class name representation.
+     *
+     * @param message the feedback message to use for css class name detection
+     * @return the css class name representation of given message
+     */
+    private String toClassName(final FeedbackMessage message) {
+         return newFeedbackMessageToCssClassNameTransformer().apply(message);
+    }
+
+    /**
+     * Transforms a {@link FeedbackMessage} to a css class name.
+     */
+    public static class FeedbackMessageToCssClassNameTransformer implements Function<FeedbackMessage, String> {
+
+        @Override
+        public String apply(final FeedbackMessage message) {
+
+            if (message == null) {
+                return "";
+            }
+
+            switch (message.getLevel()) {
+                case FeedbackMessage.FATAL:
+                case FeedbackMessage.ERROR:
+                case FeedbackMessage.WARNING: return "is-invalid";
+                case FeedbackMessage.INFO:
+                case FeedbackMessage.SUCCESS: return "is-valid";
+                default: return "";
+            }
         }
     }
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehavior.java
@@ -1,6 +1,5 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.form;
 
-import com.google.common.base.Function;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.BootstrapBaseBehavior;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.core.markup.html.bootstrap.layout.col.SpanType;
@@ -12,6 +11,7 @@ import org.apache.wicket.markup.ComponentTag;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * An {@link InputBehavior} controls the size of an input tag.

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehaviorTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/InputBehaviorTest.java
@@ -90,6 +90,28 @@ class InputBehaviorTest extends WicketApplicationTest {
         assertThat(tester().getLastResponseAsString(), Matchers.not(Matchers.containsString("</div")));
     }
 
+    @Test
+    void invalidInput() {
+        InputBehaviorPage page = new InputBehaviorPage();
+        page.textField.error("Invalid input.");
+        tester().startPage(page);
+
+        TagTester tagTester = tester().getTagById("input");
+        String cssClass = tagTester.getAttribute("class");
+        assertThat(cssClass, Matchers.containsString("is-invalid"));
+    }
+
+    @Test
+    void validInput() {
+        InputBehaviorPage page = new InputBehaviorPage();
+        page.textField.success("Valid input.");
+        tester().startPage(page);
+
+        TagTester tagTester = tester().getTagById("input");
+        String cssClass = tagTester.getAttribute("class");
+        assertThat(cssClass, Matchers.containsString("is-valid"));
+    }
+
     private static class InputBehaviorPage extends WebPage implements IMarkupResourceStreamProvider {
         private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Bootstrap 4 uses the classes `is-valid` & `is-invalid` on form controls for server side validation. See <https://getbootstrap.com/docs/4.5/components/forms/#server-side>

This PR updates the `InputBehavior` accordingly - similar to the mechanism used in `FormGroup`. 

- If the `FormComponent` contains a success or info feedback message, the `is-valid` class is appended.
- If the `FormComponent` contains a more severe feedback message, the `is-invalid` class is appended.

This fix works nicely together with my other PR #882.