### PR TITLE
deprecated FormGroup elements not properly annotated

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
@@ -39,6 +39,7 @@ public class FormGroup extends Border {
      * @deprecated Not supported by Bootstrap 4. Use {@link InputBehavior.Size}
      * on the {@link FormComponent} instead.
      */
+    @Deprecated
     public enum Size implements ICssClassNameProvider {
         Small("sm"), Large("lg");
 
@@ -115,6 +116,7 @@ public class FormGroup extends Border {
      * @deprecated Not supported by Bootstrap 4. Use
      * {@link InputBehavior#size(InputBehavior.Size)} on the {@link FormComponent} instead.
      */
+    @Deprecated
     public FormGroup size(final Size size) {
         LOG.warn("Ignore form group resizing as it is not supported by Bootstrap 4.");
         return this;


### PR DESCRIPTION
Hey Martin,

in PR #881 I forgot to add the `@Deprecated` annotation to the outdated resizing methods of `FormGroup`. A warning was shown about this during the build process. This PR should fix this minor problem. Sorry for the inconvenience.