### PR TITLE
remove guava dependency for Wicket 8.x

### DIFF
--- a/bootstrap-core/pom.xml
+++ b/bootstrap-core/pom.xml
@@ -72,11 +72,6 @@
             <artifactId>wicket-util</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
         <!-- LOGGING DEPENDENCIES - LOG4J -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/ButtonBehavior.java
@@ -1,13 +1,12 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.button;
 
-import com.google.common.base.Strings;
-
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.BootstrapBaseBehavior;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.core.util.Components;
 import de.agilecoders.wicket.core.util.CssClassNames;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.model.IModel;
@@ -92,7 +91,7 @@ public class ButtonBehavior extends BootstrapBaseBehavior {
      * @return whether this button is a block level element
      */
     public boolean isBlock() {
-        return !Strings.isNullOrEmpty(block.getObject());
+        return StringUtils.isNotBlank(block.getObject());
     }
 
     /**

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehavior.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/TooltipBehavior.java
@@ -10,7 +10,8 @@ import org.apache.wicket.model.IComponentAssignedModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.string.Strings;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
+
 import static de.agilecoders.wicket.jquery.JQuery.$;
 
 /**
@@ -75,7 +76,7 @@ public class TooltipBehavior extends BootstrapJavascriptBehavior {
     private IModel<String> wrapOnAssignment(IModel<String> label, Component component) {
         if (label != null && label instanceof IComponentAssignedModel) {
             IComponentAssignedModel<String> cam = (IComponentAssignedModel<String>) label;
-            return cam.wrapOnAssignment(checkNotNull(component));
+            return cam.wrapOnAssignment(Objects.requireNonNull(component));
         }
         return label;
     }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/FormGroup.java
@@ -1,6 +1,5 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.form;
 
-import com.google.common.base.Function;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.core.util.Components;
@@ -24,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Simple form control group that is able to show a label, help text and feedback

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/request/resource/caching/version/ChecksumResourceVersion.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/request/resource/caching/version/ChecksumResourceVersion.java
@@ -1,7 +1,6 @@
 package de.agilecoders.wicket.core.request.resource.caching.version;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.Application;
 import org.apache.wicket.request.resource.caching.version.MessageDigestResourceVersion;
 import org.apache.wicket.util.io.IOUtils;
@@ -9,6 +8,7 @@ import org.apache.wicket.util.io.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 import java.util.zip.Checksum;
 
@@ -38,12 +38,12 @@ public abstract class ChecksumResourceVersion extends MessageDigestResourceVersi
         if (Application.exists()) {
             final String charset = Application.get().getMarkupSettings().getDefaultMarkupEncoding();
 
-            if (!Strings.isNullOrEmpty(charset)) {
+            if (StringUtils.isNotBlank(charset)) {
                 return Charset.forName(charset);
             }
         }
 
-        return Charsets.UTF_8;
+        return StandardCharsets.UTF_8;
     }
 
     /**

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/util/CssClassNames.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/util/CssClassNames.java
@@ -1,15 +1,15 @@
 package de.agilecoders.wicket.core.util;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.ICssClassNameProvider;
 import de.agilecoders.wicket.jquery.util.Generics2;
 import de.agilecoders.wicket.jquery.util.Strings2;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.lang.Args;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -21,8 +21,6 @@ import java.util.Set;
  * @author Michael Haitz <michael.haitz@agilecoders.de>
  */
 public final class CssClassNames {
-    private static final Splitter SPLITTER = Splitter.on(' ').trimResults().omitEmptyStrings();
-    private static final Joiner JOINER = Joiner.on(' ').skipNulls();
 
     /**
      * creates a new {@link ICssClassNameProvider} from a given model.
@@ -55,7 +53,7 @@ public final class CssClassNames {
      * @return the joined class names.
      */
     public static String join(Iterable<String> classNames) {
-        return JOINER.join(classNames);
+        return StringUtils.join(classNames, " ");
     }
 
     /**
@@ -65,7 +63,19 @@ public final class CssClassNames {
      * @return a new set of css class names.
      */
     public static Set<String> split(final CharSequence classValue) {
-        return Generics2.newLinkedHashSet(SPLITTER.split(classValue));
+        final Set<String> result = new LinkedHashSet<>();
+        final String clazzes = (classValue != null) ? classValue.toString() : null;
+
+        if (StringUtils.isNotBlank(clazzes)) {
+            for (String clazz : StringUtils.split(clazzes, " ")) {
+                clazz = StringUtils.trimToNull(clazz);
+                if (clazz != null) {
+                    result.add(clazz);
+                }
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/WicketApplicationTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/WicketApplicationTest.java
@@ -1,6 +1,5 @@
 package de.agilecoders.wicket.core;
 
-import com.google.common.base.Charsets;
 import de.agilecoders.wicket.core.settings.BootstrapSettings;
 import de.agilecoders.wicket.core.settings.IBootstrapSettings;
 import de.agilecoders.wicket.core.test.Attributes;
@@ -20,6 +19,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,7 +65,7 @@ public abstract class WicketApplicationTest extends Assertions {
                     .install(this);
 
                 getMarkupSettings().setStripWicketTags(false);
-                getMarkupSettings().setDefaultMarkupEncoding(Charsets.UTF_8.name());
+                getMarkupSettings().setDefaultMarkupEncoding(StandardCharsets.UTF_8.name());
 
                 WicketApplicationTest.this.init(this);
             }

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/carousel/CarouselTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/carousel/CarouselTest.java
@@ -1,11 +1,11 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.carousel;
 
-import com.google.common.collect.Lists;
 import de.agilecoders.wicket.core.WicketApplicationTest;
 import org.apache.wicket.util.string.Strings;
 import org.apache.wicket.util.tester.TagTester;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -102,7 +102,7 @@ class CarouselTest extends WicketApplicationTest {
      * @return a list of carousel images
      */
     private List<ICarouselImage> newImageList() {
-        return Lists.newArrayList(
+        return Arrays.asList(
                 new CarouselImage("http://wb.agilecoders.de/image1.png"),
                 new CarouselImage("http://wb.agilecoders.de/image2.png", "header text"),
                 new CarouselImage("http://wb.agilecoders.de/image3.png", "header text", "description")

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/BootstrapRadioChoiceTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/BootstrapRadioChoiceTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-import com.google.common.collect.Lists;
+import java.util.Arrays;
 import org.apache.wicket.util.tester.TagTester;
 
 import de.agilecoders.wicket.core.WicketApplicationTest;
@@ -17,7 +17,7 @@ class BootstrapRadioChoiceTest extends WicketApplicationTest {
 
     @Test
     void radioChoice() {
-        BootstrapRadioChoice<String> radio = new BootstrapRadioChoice<>("id", Lists.newArrayList("One", "Two"));
+        BootstrapRadioChoice<String> radio = new BootstrapRadioChoice<>("id", Arrays.asList("One", "Two"));
 
         tester().startComponentInPage(radio);
         TagTester spanTester = tester().getTagByWicketId("id");
@@ -38,7 +38,7 @@ class BootstrapRadioChoiceTest extends WicketApplicationTest {
 
     @Test
     void inlineRadioChoice() {
-        BootstrapRadioChoice<String> radio = new BootstrapRadioChoice<>("id", Lists.newArrayList("One", "Two"));
+        BootstrapRadioChoice<String> radio = new BootstrapRadioChoice<>("id", Arrays.asList("One", "Two"));
         radio.setInline(true);
 
         tester().startComponentInPage(radio);

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/list/BootstrapListViewTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/list/BootstrapListViewTest.java
@@ -1,12 +1,13 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.list;
 
-import com.google.common.collect.Lists;
 import de.agilecoders.wicket.core.WicketApplicationTest;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.util.tester.TagTester;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,7 +23,7 @@ class BootstrapListViewTest extends WicketApplicationTest {
 
     @Test
     void listViewIsRendered() {
-        TagTester tag = startComponentInPage(new BootstrapListView<String>(id(), Lists.newArrayList("item1")) {
+        TagTester tag = startComponentInPage(new BootstrapListView<String>(id(), Collections.singletonList("item1")) {
             @Override
             protected void populateItem(ListItem<String> components) {
                 components.add(new Label("sub", components.getModelObject()));
@@ -35,7 +36,7 @@ class BootstrapListViewTest extends WicketApplicationTest {
 
     @Test
     void listViewWithModelIsRendered() {
-        TagTester tag = startComponentInPage(new BootstrapListView<String>(id(), Model.ofList(Lists.newArrayList("item1"))) {
+        TagTester tag = startComponentInPage(new BootstrapListView<String>(id(), Model.ofList(Collections.singletonList("item1"))) {
             @Override
             protected void populateItem(ListItem<String> components) {
                 components.add(new Label("sub", components.getModelObject()));

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/ClientSideBootstrapTabbedPanelTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/tabs/ClientSideBootstrapTabbedPanelTest.java
@@ -9,9 +9,8 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.util.tester.TagTester;
 
-import com.google.common.collect.Lists;
-
 import de.agilecoders.wicket.core.WicketApplicationTest;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class ClientSideBootstrapTabbedPanelTest extends WicketApplicationTest {
@@ -119,7 +118,7 @@ class ClientSideBootstrapTabbedPanelTest extends WicketApplicationTest {
     }
 
     private Component newClientSideTabs(String markupId, IModel<Integer> activeTab) {
-        return new ClientSideBootstrapTabbedPanel<>(markupId, Lists.newArrayList(
+        return new ClientSideBootstrapTabbedPanel<>(markupId, Arrays.asList(
                 createTab("Section 1"), createTab("Section 2"), createTab("Section 3")
         ), activeTab);
     }

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/request/resource/caching/version/ChecksumResourceVersionTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/request/resource/caching/version/ChecksumResourceVersionTest.java
@@ -1,9 +1,8 @@
 package de.agilecoders.wicket.core.request.resource.caching.version;
 
-import com.google.common.base.Charsets;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,11 +21,11 @@ abstract class ChecksumResourceVersionTest {
         final ChecksumResourceVersion version = newChecksumResourceVersion();
 
         try {
-            final byte[] versionAsByteArray = version.computeDigest(new ByteArrayInputStream(input.getBytes(Charsets.UTF_8)));
+            final byte[] versionAsByteArray = version.computeDigest(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
 
             assertThat("checksum(" + input + "): " + expected + "; is: " + new String(versionAsByteArray),
                        versionAsByteArray,
-                       is(equalTo(expected.getBytes(Charsets.UTF_8))));
+                       is(equalTo(expected.getBytes(StandardCharsets.UTF_8))));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/request/resource/caching/version/ChecksumResourceVersionWTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/request/resource/caching/version/ChecksumResourceVersionWTest.java
@@ -1,7 +1,7 @@
 package de.agilecoders.wicket.core.request.resource.caching.version;
 
-import com.google.common.base.Charsets;
 import de.agilecoders.wicket.core.WicketApplicationTest;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -29,16 +29,16 @@ class ChecksumResourceVersionWTest extends WicketApplicationTest {
 
     @Test
     void defaultMarkupEncodingIsUsed() {
-        application().getMarkupSettings().setDefaultMarkupEncoding(Charsets.UTF_16.name());
+        application().getMarkupSettings().setDefaultMarkupEncoding(StandardCharsets.UTF_16.name());
 
-        assertThat(new Adler32ResourceVersion().charset(), is(equalTo(Charsets.UTF_16)));
+        assertThat(new Adler32ResourceVersion().charset(), is(equalTo(StandardCharsets.UTF_16)));
     }
 
     @Test
     void fallbackIsUsedIfThereIsNoDefaultMarkupEncoding() {
         application().getMarkupSettings().setDefaultMarkupEncoding(null);
 
-        assertThat(new Adler32ResourceVersion().charset(), is(equalTo(Charsets.UTF_8)));
+        assertThat(new Adler32ResourceVersion().charset(), is(equalTo(StandardCharsets.UTF_8)));
     }
 
 }

--- a/bootstrap-extensions/pom.xml
+++ b/bootstrap-extensions/pom.xml
@@ -65,11 +65,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.javascript</groupId>
             <artifactId>closure-compiler-unshaded</artifactId>
             <version>${google-closure.version}</version>

--- a/bootstrap-themes/src/main/java/de/agilecoders/wicket/themes/markup/html/bootswatch/BootswatchThemeProvider.java
+++ b/bootstrap-themes/src/main/java/de/agilecoders/wicket/themes/markup/html/bootswatch/BootswatchThemeProvider.java
@@ -1,12 +1,13 @@
 package de.agilecoders.wicket.themes.markup.html.bootswatch;
 
-import com.google.common.collect.ImmutableList;
 import de.agilecoders.wicket.core.settings.ITheme;
 import de.agilecoders.wicket.core.settings.ThemeProvider;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.string.Strings;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -31,7 +32,7 @@ public class BootswatchThemeProvider implements ThemeProvider {
      * Constructor.
      */
     public BootswatchThemeProvider(final BootswatchTheme defaultTheme) {
-        this.themes = ImmutableList.<ITheme>builder().add(BootswatchTheme.values()).build();
+        this.themes = Collections.unmodifiableList(Arrays.asList(BootswatchTheme.values()));
         this.defaultTheme = Args.notNull(defaultTheme, "defaultTheme");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
         <mockito.version>3.6.0</mockito.version>
         <yuicompressor.version>2.4.8</yuicompressor.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-        <guava.version>30.0</guava.version>
         <junit5.version>5.7.0</junit5.version>
         <wicket.version>8.9.0</wicket.version>
         <wicketstuff.version>8.9.0</wicketstuff.version>
@@ -237,12 +236,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}-jre</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Hey Martin,

similar to #885 this PR removes the Guava dependency for Wicket 8.x and avoids conflicts on merge / backport.