### PR TITLE
#888 - Illegal char in path on Windows

### DIFF
--- a/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/UrlImporter.java
+++ b/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/UrlImporter.java
@@ -185,6 +185,7 @@ class UrlImporter implements Importer {
 
     private Optional<Import> resolveLocalDependency(URI base, String url) {
         LOG.debug("Going to resolve an import from local dependency: {}", url);
+
         String importUrl = getAbsolutePath(base, url);
         Optional<Import> localImport = resolveLocalFileDependency(importUrl);
 
@@ -231,8 +232,8 @@ class UrlImporter implements Importer {
 
     private String getAbsolutePath(URI base, String url) {
         String basePath = base.toString();
-        Path parentBasePath = Paths.get(basePath).getParent();
-        return parentBasePath.resolve(url).toString();
+        String parentBasePath = basePath.substring(0, basePath.lastIndexOf('/'));
+        return parentBasePath + '/' + url;
     }
 
     private Import buildImport(URL importUri) {

--- a/bootstrap-sass/src/test/java/de/agilecoders/wicket/sass/BootstrapSassTest.java
+++ b/bootstrap-sass/src/test/java/de/agilecoders/wicket/sass/BootstrapSassTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.net.URL;
 
+import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -61,7 +62,7 @@ class BootstrapSassTest {
 
         SassSource sassSource = sass.getSassContext(res, null);
         String css = sass.getCss(sassSource);
-        assertThat(css, is(equalTo(".rule {\n  background: #999; }\n")));
+        assertThat(css, is(equalTo(".rule {" + lineSeparator() + "  background: #999; }" + lineSeparator())));
     }
 
     /**
@@ -89,7 +90,7 @@ class BootstrapSassTest {
 
         SassSource sassSource = sass.getSassContext(res, null);
         String css = sass.getCss(sassSource);
-        assertThat(css, is(equalTo(".rule {\n  background: #007bff; }\n")));
+        assertThat(css, is(equalTo(".rule {" + lineSeparator() + "  background: #007bff; }" + lineSeparator())));
     }
 
     @Test
@@ -99,7 +100,7 @@ class BootstrapSassTest {
 
         SassSource sassSource = sass.getSassContext(res, null);
         String css = sass.getCss(sassSource);
-        assertThat(css, is(equalTo(".classPathImported {\n  color: #333; }\n")));
+        assertThat(css, is(equalTo(".classPathImported {" + lineSeparator() + "  color: #333; }" + lineSeparator())));
     }
 
     @Test
@@ -157,7 +158,7 @@ class BootstrapSassTest {
 
         SassSource sassSource = sass.getSassContext(res, null);
         String css = sass.getCss(sassSource);
-        assertThat(css, is(".my-class {\n  color: blue; }\n"));
+        assertThat(css, is(".my-class {" + lineSeparator() + "  color: blue; }" + lineSeparator()));
     }
 
     public static class TestFunctions {


### PR DESCRIPTION
Fixes https://github.com/l0rdn1kk0n/wicket-bootstrap/issues/888 . 
The issue seems to be that URIs pointing to jar contents are not valid paths.

I would prefer to use a URI Builder, but do not want to add a dependency just for that.

See also https://github.com/inception-project/inception/issues/1858