### PR TITLE
FontAwesome5CDNCSSReference: Align version used in URL

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5CDNCSSReference.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/icon/FontAwesome5CDNCSSReference.java
@@ -18,7 +18,7 @@ import org.apache.wicket.request.resource.UrlResourceReference;
  */
 public class FontAwesome5CDNCSSReference extends UrlResourceReference{
     private static final long serialVersionUID = 1L;
-    private static final String CDNURL = "https://use.fontawesome.com/releases/v5.14.0/css/all.css";
+    private static final String CDNURL = "https://use.fontawesome.com/releases/v5.15.0/css/all.css";
 
     /**
      * Singleton instance of this reference


### PR DESCRIPTION
Commit 655198d3eb made me realize my last few PRs regarding font-awesome were not correctly aligning the version used in the URL of `FontAwesome5CDNCSSReference`. Sorry about that.

However, above commit bumps it only to version 5.14.0. The version we reference with the non-CDN approach is already 5.15.0.