### PR TITLE
Use JQuery's hide() method on the component so there is no gap in DOM

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/checkbox/bootstrapcheckbox/BootstrapCheckBoxPicker.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/checkbox/bootstrapcheckbox/BootstrapCheckBoxPicker.java
@@ -111,8 +111,9 @@ public class BootstrapCheckBoxPicker extends CheckBox {
 
         response.render(JavaScriptHeaderItem.forReference(new JQueryPluginResourceReference(BootstrapCheckBoxPicker.class, "js/bootstrap-checkbox.js")));
         response.render(OnDomReadyHeaderItem.forScript($(this).chain("checkboxpicker", getConfig()).get()));
+        
         // Bootstrap4 dropped hidden for invisible, so we have to hide input manually.
-        response.render(OnDomReadyHeaderItem.forScript(String.format("$(%s).addClass('invisible');", getMarkupId())));
+        response.render(OnDomReadyHeaderItem.forScript(String.format("$(%s).hide();", getMarkupId())));
     }
 
     /*


### PR DESCRIPTION
If you add class `invisible`, component disappears but still takes up space, breaking the form layout.