### PR TITLE
fix: [#925] Downgrade closure-compiler-unshaded from v20210601 to v20200830

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <contiperf.version>2.4.3</contiperf.version>
         <doxia.version>1.0</doxia.version>
-        <google-closure.version>v20210601</google-closure.version>
+        <!-- Note: closure-compiler -unshaded v20200920 (until at least v20210907) contains gson -->
+        <google-closure.version>v20200830</google-closure.version>
         <javax.javaee-web-api.version>7.0</javax.javaee-web-api.version>
         <jetty.version>9.4.42.v20210604</jetty.version>
         <joda-time.version>2.10.10</joda-time.version>


### PR DESCRIPTION
Fixes #925.

closure-compiler-unshaded v20200830 is the last version (verified until current 20210907) not
containing gson. Downgrading to the last good known version to avoid issues from PR #797.

Please also port to `wicket-9.x-bootstrap-4.x