### PR TITLE
Bump closure-compiler-unshaded from v20200406 to v20200830

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
         <modernizr.version>2.8.3</modernizr.version>
         <guava.version>30.1.1</guava.version>
         <jetty.version>9.4.39.v20210325</jetty.version>
-        <google-closure.version>v20200406</google-closure.version>
+        <!-- Note: closure-compiler-unshaded v20200920 (until at least v20210907) contains gson -->
+        <google-closure.version>v20200830</google-closure.version>
         <contiperf.version>2.4.3</contiperf.version>
         <jquerypp.version>1.0.1</jquerypp.version>
         <jquery.version>2.2.4</jquery.version>


### PR DESCRIPTION
While there are newer versions of closure-compiler available (v20200517), all starting
from v20200920 onwards still ship gson in version 2.7, potentially clashing with other
versions used in the projects depending on wicket-bootstrap and transitively on
closure-compiler. See PR #797.

This PR was created in the context of #925. While branch `wicket-9.x` was not affected from
the issue in that ticket, this PR bumps and thus pulls along the version of closure-compiler.