### PR TITLE
BootstrapGenericPanel - set default model to topImage to prevent lookup

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/panel/BootstrapGenericPanel.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/panel/BootstrapGenericPanel.java
@@ -155,7 +155,7 @@ public class BootstrapGenericPanel<T> extends GenericPanel<T>{
      */
 	protected Component newTopImage(String id, IModel<T> model) {
 	    Panel emptyTopImage = new EmptyPanel(id);
-	    emptyTopImage.setDefaultModel(null);
+	    emptyTopImage.setDefaultModel(new Model<>());
 
 	    return emptyTopImage;
     }


### PR DESCRIPTION
Without the model, Wicket always traversed the hierarchy up to find a model it could use.