### PR TITLE
Make FileInputConfig maxFileSize and minFileSize aware

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
@@ -39,6 +39,10 @@ public class FileInputConfig extends AbstractConfig {
 
     public static final IKey<Integer> MinFileCount = newKey("minFileCount", 0);
 
+    public static final IKey<Integer> MaxFileSize = newKey("maxFileSize", 0);
+
+    public static final IKey<Integer> MinFileSize = newKey("minFileSize", 0);
+
     public static final IKey<String> BrowseIcon = newKey("browseIcon", "<i class=\"glyphicon glyphicon-folder-open\"></i> &nbsp;");
 
     public static final IKey<String> RemoveIcon = newKey("removeIcon", "<i class=\"glyphicon glyphicon-trash\"></i> &nbsp;");
@@ -134,6 +138,18 @@ public class FileInputConfig extends AbstractConfig {
 
     public FileInputConfig maxFileCount(int maxFileCount) {
         put(MaxFileCount, maxFileCount);
+        return this;
+    }
+
+    /** Maximum file size for upload in KB - 0 (default) for no restriction on maximum file size */
+    public FileInputConfig maxFileSize(int maxFileSize) {
+        put(MaxFileSize, maxFileSize);
+        return this;
+    }
+
+    /** Minimum file size for upload in KB - 0 (default) for no restriction on minimum file size */
+    public FileInputConfig minFileSize(int minFileSize) {
+        put(MinFileSize, minFileSize);
         return this;
     }
 
@@ -253,6 +269,14 @@ public class FileInputConfig extends AbstractConfig {
 
     public int wrapTextLength() {
         return get(WrapTextLength);
+    }
+
+    public int maxFileSize() {
+        return get(MaxFileSize);
+    }
+
+    public int minFileSize() {
+        return get(MinFileSize);
     }
 
     public String browseIcon() {

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
@@ -2,6 +2,7 @@ package de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput;
 
 import de.agilecoders.wicket.jquery.AbstractConfig;
 import de.agilecoders.wicket.jquery.IKey;
+import org.apache.wicket.util.lang.Bytes;
 
 import java.util.List;
 
@@ -141,15 +142,15 @@ public class FileInputConfig extends AbstractConfig {
         return this;
     }
 
-    /** Maximum file size for upload in KB - 0 (default) for no restriction on maximum file size */
-    public FileInputConfig maxFileSize(int maxFileSize) {
-        put(MaxFileSize, maxFileSize);
+    /** Maximum file size for upload - or no restriction if 0 (default) */
+    public FileInputConfig maxFileSize(Bytes maxFileSize) {
+        put(MaxFileSize, maxFileSize != null ? (int) Math.round(maxFileSize.kilobytes()) : 0);
         return this;
     }
 
-    /** Minimum file size for upload in KB - 0 (default) for no restriction on minimum file size */
-    public FileInputConfig minFileSize(int minFileSize) {
-        put(MinFileSize, minFileSize);
+    /** Minimum file size for upload - or no restriction if 0 (default) */
+    public FileInputConfig minFileSize(Bytes minFileSize) {
+        put(MinFileSize, minFileSize != null ? (int) Math.round(minFileSize.kilobytes()) : 0);
         return this;
     }
 
@@ -273,12 +274,12 @@ public class FileInputConfig extends AbstractConfig {
         return get(MinFileCount);
     }
 
-    public int maxFileSize() {
-        return get(MaxFileSize);
+    public Bytes maxFileSize() {
+        return Bytes.kilobytes(get(MaxFileSize));
     }
 
-    public int minFileSize() {
-        return get(MinFileSize);
+    public Bytes minFileSize() {
+        return Bytes.kilobytes(get(MinFileSize));
     }
 
     public String browseIcon() {

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
@@ -216,14 +216,6 @@ public class FileInputConfig extends AbstractConfig {
     	put(DropZoneClickTitle, dropZoneClickTitle);
     	return this;
     }
-    
-    public List<String> allowedFileTypes() {
-        return get(AllowedFileTypes);
-    }
-
-    public List<String> allowedFileExtensions() {
-        return get(AllowedFileExtensions);
-    }
 
     public boolean showCaption() {
         return get(ShowCaption);
@@ -243,6 +235,10 @@ public class FileInputConfig extends AbstractConfig {
 
     public String captionClass() {
         return getString(CaptionClass);
+    }
+
+    public String previewClass() {
+        return getString(PreviewClass);
     }
 
     public String mainClass() {
@@ -269,6 +265,14 @@ public class FileInputConfig extends AbstractConfig {
         return get(WrapTextLength);
     }
 
+    public int maxFileCount() {
+        return get(MaxFileCount);
+    }
+
+    public int minFileCount() {
+        return get(MinFileCount);
+    }
+
     public int maxFileSize() {
         return get(MaxFileSize);
     }
@@ -289,8 +293,20 @@ public class FileInputConfig extends AbstractConfig {
         return get(UploadIcon);
     }
 
+    public String cancelIcon() {
+        return get(CancelIcon);
+    }
+
     public String previewFileType() {
         return get(PreviewFileType);
+    }
+
+    public List<String> allowedFileExtensions() {
+        return get(AllowedFileExtensions);
+    }
+
+    public List<String> allowedFileTypes() {
+        return get(AllowedFileTypes);
     }
 
     public String language() {

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfig.java
@@ -189,10 +189,8 @@ public class FileInputConfig extends AbstractConfig {
     }
 
     /**
-     * Sets fileinput language. See {@link de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.res.locales}
-     *
-     * @param language
-     * @return config
+     * Sets fileinput language.
+     * See {@link de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.res.js.locales}
      */
     public FileInputConfig withLocale(String language) {
     	put(Language, language);

--- a/bootstrap-extensions/src/test/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfigTest.java
+++ b/bootstrap-extensions/src/test/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/fileinput/FileInputConfigTest.java
@@ -1,0 +1,108 @@
+package de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.apache.wicket.util.lang.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class FileInputConfigTest {
+    private FileInputConfig config;
+
+    @BeforeEach
+    void setUp() {
+        config = new FileInputConfig();
+    }
+
+    @Nested
+    class MaxFileSizeTests {
+        @Test
+        void whenNotSetting_isZero() {
+            assertThat(config.maxFileSize(), is(Bytes.kilobytes(0.0)));
+            assertThat(config.get(FileInputConfig.MaxFileSize), is(0));
+        }
+
+        @Test
+        void whenSettingToZero_isZero() {
+            config = config.maxFileSize(Bytes.bytes(0));
+            assertThat(config.maxFileSize(), is(Bytes.kilobytes(0.0)));
+            assertThat(config.get(FileInputConfig.MaxFileSize), is(0));
+        }
+
+        @Test
+        void whenSetting_isSetToKb() {
+            config = config.maxFileSize(Bytes.bytes(1024.0));
+            assertThat(config.maxFileSize(), is(Bytes.kilobytes(1.0)));
+            assertThat(config.get(FileInputConfig.MaxFileSize), is(1));
+        }
+
+        @Test
+        void whenSettingToBytes_isRoundedToKb_down() {
+            config = config.maxFileSize(Bytes.bytes(1535));
+            assertThat(config.maxFileSize(), is(Bytes.bytes(1024)));
+            assertThat(config.get(FileInputConfig.MaxFileSize), is(1));
+        }
+
+        @Test
+        void whenSettingToBytes_isRoundedToKb_up() {
+            config = config.maxFileSize(Bytes.bytes(1537));
+            assertThat(config.maxFileSize(), is(Bytes.bytes(2048)));
+            assertThat(config.get(FileInputConfig.MaxFileSize), is(2));
+        }
+
+        @Test
+        void whenSettingTwice_isSetToSecondValue() {
+            config = config.maxFileSize(Bytes.bytes(1024));
+            config = config.maxFileSize(Bytes.megabytes(10));
+            assertThat(config.maxFileSize(), is(Bytes.bytes(10_485_760)));
+            assertThat(config.get(FileInputConfig.MaxFileSize), is(10_240));
+        }
+    }
+
+    @Nested
+    class MinFileSizeTests {
+        @Test
+        void whenNotSetting_isZero() {
+            assertThat(config.minFileSize(), is(Bytes.kilobytes(0.0)));
+            assertThat(config.get(FileInputConfig.MinFileSize), is(0));
+        }
+
+        @Test
+        void whenSettingToZero_isZero() {
+            config = config.minFileSize(Bytes.bytes(0));
+            assertThat(config.minFileSize(), is(Bytes.kilobytes(0.0)));
+            assertThat(config.get(FileInputConfig.MinFileSize), is(0));
+        }
+
+        @Test
+        void whenSetting_isSetToKb() {
+            config = config.minFileSize(Bytes.bytes(1024.0));
+            assertThat(config.minFileSize(), is(Bytes.kilobytes(1.0)));
+            assertThat(config.get(FileInputConfig.MinFileSize), is(1));
+        }
+
+        @Test
+        void whenSettingToBytes_isRoundedToKb_down() {
+            config = config.minFileSize(Bytes.bytes(1535));
+            assertThat(config.minFileSize(), is(Bytes.bytes(1024)));
+            assertThat(config.get(FileInputConfig.MinFileSize), is(1));
+        }
+
+        @Test
+        void whenSettingToBytes_isRoundedToKb_up() {
+            config = config.minFileSize(Bytes.bytes(1537));
+            assertThat(config.minFileSize(), is(Bytes.bytes(2048)));
+            assertThat(config.get(FileInputConfig.MinFileSize), is(2));
+        }
+
+        @Test
+        void whenSettingTwice_isSetToSecondValue() {
+            config = config.minFileSize(Bytes.bytes(1024));
+            config = config.minFileSize(Bytes.megabytes(10));
+            assertThat(config.minFileSize(), is(Bytes.bytes(10_485_760)));
+            assertThat(config.get(FileInputConfig.MinFileSize), is(10_240));
+        }
+    }
+}


### PR DESCRIPTION
While it's technically possible to add e.g. the "maxFileSize" configuration via `.getConfig().put(...)` to the `FileInputConfig`, it's IMHO a nice addition to make the config aware of that parameter. Added for symmetry reasons also "minFileSize".

As a side change, all paramters now also have a getter and the locales path in a javadoc comment is fixed.