### PR TITLE
Issue #914: wicket-bootstrap-sass not working on Apple Silicon

### DIFF
--- a/bootstrap-sass/pom.xml
+++ b/bootstrap-sass/pom.xml
@@ -21,7 +21,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.bit3</groupId>
+            <groupId>ua.kasta</groupId>
             <artifactId>jsass</artifactId>
             <version>${jsass.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <jquery.version>3.6.1</jquery.version>
         <junit-jupiter.version>5.9.1</junit-jupiter.version>
         <junit-platform.version>1.9.1</junit-platform.version>
-        <jsass.version>5.10.4</jsass.version>
+        <jsass.version>5.10.5</jsass.version>
         <hamcrest.version>2.2</hamcrest.version>
         <logback.version>1.2.10</logback.version>
         <modernizr.version>2.8.3-1</modernizr.version>
@@ -593,6 +593,10 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>repo.clojars.org</id>
+            <url>https://repo.clojars.org</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
- Switch to ua.kasta:jsass which works on Apple Silicon