### PR TITLE
Replace .sr-only with .visually-hidden, use static Helper.screenReaderOnly class where applicable, fix SpinnerAjax(Button|Link) label rendering

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/dropdown/SplitButton.html
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/button/dropdown/SplitButton.html
@@ -7,7 +7,7 @@
             <button type="button" class="btn" wicket:id="button"></button>
             <button type="button" class="btn dropdown-toggle dropdown-toggle-split" wicket:id="caret" 
                     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="sr-only"></span>
+                <span class="visually-hidden"></span>
             </button>
             <div wicket:id="dropdown-menu" class="dropdown-menu">
                 <wicket:container wicket:id="buttons">

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.html
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:wicket="http://wicket.apache.org">
     <body>
-        <wicket:panel><span wicket:id="srOnly" class="sr-only"></span></wicket:panel>
+        <wicket:panel><span wicket:id="srOnly"></span></wicket:panel>
     </body>
 </html>

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.html
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:wicket="http://wicket.apache.org">
     <body>
-        <wicket:panel><span wicket:id="srOnly"></span></wicket:panel>
+        <wicket:panel><span wicket:id="visuallyHidden"></span></wicket:panel>
     </body>
 </html>

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.java
@@ -1,5 +1,6 @@
 package de.agilecoders.wicket.core.markup.html.bootstrap.components.progress;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
@@ -9,6 +10,7 @@ import org.apache.wicket.model.IModel;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.utilities.BackgroundColorBehavior;
 import de.agilecoders.wicket.core.util.Attributes;
+import de.agilecoders.wicket.core.util.CssClassNames.Helper;
 
 /**
  * Represents a stack of the progress bar.
@@ -57,6 +59,7 @@ public class Stack extends GenericPanel<Integer> {
         super.onInitialize();
 
         srOnly = new Label("srOnly", createLabelModel());
+        srOnly.add(AttributeModifier.append("class", Helper.screenReaderOnly));
         add(srOnly);
     }
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/Stack.java
@@ -21,7 +21,7 @@ public class Stack extends GenericPanel<Integer> {
     /**
      * A label for the stack's progress
      */
-    private Label srOnly;
+    private Label visuallyHidden;
 
     /**
      * The color type of the stack
@@ -58,9 +58,9 @@ public class Stack extends GenericPanel<Integer> {
     protected void onInitialize() {
         super.onInitialize();
 
-        srOnly = new Label("srOnly", createLabelModel());
-        srOnly.add(AttributeModifier.append("class", Helper.screenReaderOnly));
-        add(srOnly);
+        visuallyHidden = new Label("visuallyHidden", createLabelModel());
+        visuallyHidden.add(AttributeModifier.append("class", Helper.visuallyHidden));
+        add(visuallyHidden);
     }
 
     public BackgroundColorBehavior.Color color() {
@@ -108,7 +108,7 @@ public class Stack extends GenericPanel<Integer> {
         super.onConfigure();
 
         if (labeled()) {
-            srOnly.setRenderBodyOnly(true);
+            visuallyHidden.setRenderBodyOnly(true);
         }
     }
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/util/CssClassNames.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/util/CssClassNames.java
@@ -236,7 +236,7 @@ public final class CssClassNames {
     @SuppressWarnings("UnusedDeclaration")
     public static final class Helper {
         public static final String clearfix = "clearfix";
-        public static final String screenReaderOnly = "visually-hidden";
+        public static final String visuallyHidden = "visually-hidden";
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/util/CssClassNames.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/util/CssClassNames.java
@@ -236,7 +236,7 @@ public final class CssClassNames {
     @SuppressWarnings("UnusedDeclaration")
     public static final class Helper {
         public static final String clearfix = "clearfix";
-        public static final String screenReaderOnly = "sr-only";
+        public static final String screenReaderOnly = "visually-hidden";
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/ProgressBarTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/ProgressBarTest.java
@@ -59,7 +59,7 @@ class ProgressBarTest extends WicketApplicationTest {
         assertEquals("" + ProgressBar.MIN, stackTester.getAttribute("aria-valuemin"));
         assertEquals("" + ProgressBar.MAX, stackTester.getAttribute("aria-valuemax"));
 
-        TagTester stackLabelTester = stackTester.getChild("class", Helper.screenReaderOnly);
+        TagTester stackLabelTester = stackTester.getChild("class", Helper.visuallyHidden);
         assertEquals("" + progress + "%", stackLabelTester.getValue());
     }
 

--- a/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/ProgressBarTest.java
+++ b/bootstrap-core/src/test/java/de/agilecoders/wicket/core/markup/html/bootstrap/components/progress/ProgressBarTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import de.agilecoders.wicket.core.WicketApplicationTest;
 import de.agilecoders.wicket.core.markup.html.bootstrap.utilities.BackgroundColorBehavior;
+import de.agilecoders.wicket.core.util.CssClassNames.Helper;
 
 /**
  * Tests for ProgressBar
@@ -58,7 +59,7 @@ class ProgressBarTest extends WicketApplicationTest {
         assertEquals("" + ProgressBar.MIN, stackTester.getAttribute("aria-valuemin"));
         assertEquals("" + ProgressBar.MAX, stackTester.getAttribute("aria-valuemax"));
 
-        TagTester stackLabelTester = stackTester.getChild("class", "sr-only");
+        TagTester stackLabelTester = stackTester.getChild("class", Helper.screenReaderOnly);
         assertEquals("" + progress + "%", stackLabelTester.getValue());
     }
 

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxButton.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxButton.java
@@ -103,11 +103,11 @@ public class SpinnerAjaxButton extends BootstrapAjaxButton {
     }
 
     @Override
-    protected <L extends Serializable> Component newLabel(String markupId, IModel<L> model) {
-        Component label = super.newLabel(markupId, model);
+    protected void onConfigure() {
+    	super.onConfigure();
+    	Component label = get("label");
         if (Strings.isEmpty(label.getDefaultModelObjectAsString())) {
-            label.add(AttributeModifier.append("class", "sr-only"));
+        	label.add(AttributeModifier.append("class", "sr-only"));
         }
-        return label;
     }
 }

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxButton.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxButton.java
@@ -108,7 +108,7 @@ public class SpinnerAjaxButton extends BootstrapAjaxButton {
     	super.onConfigure();
     	Component label = get("label");
         if (Strings.isEmpty(label.getDefaultModelObjectAsString())) {
-        	label.add(AttributeModifier.append("class", Helper.screenReaderOnly));
+        	label.add(AttributeModifier.append("class", Helper.visuallyHidden));
         }
     }
 }

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxButton.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxButton.java
@@ -11,6 +11,7 @@ import org.apache.wicket.util.string.Strings;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.BootstrapAjaxButton;
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.Buttons;
+import de.agilecoders.wicket.core.util.CssClassNames.Helper;
 
 /**
  * A specialization of {@link de.agilecoders.wicket.core.markup.html.bootstrap.button.BootstrapAjaxButton}
@@ -107,7 +108,7 @@ public class SpinnerAjaxButton extends BootstrapAjaxButton {
     	super.onConfigure();
     	Component label = get("label");
         if (Strings.isEmpty(label.getDefaultModelObjectAsString())) {
-        	label.add(AttributeModifier.append("class", "sr-only"));
+        	label.add(AttributeModifier.append("class", Helper.screenReaderOnly));
         }
     }
 }

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxLink.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxLink.java
@@ -94,9 +94,15 @@ public abstract class SpinnerAjaxLink<T> extends BootstrapAjaxLink<T> {
     protected <L extends Serializable> Component newLabel(String markupId, IModel<L> model) {
         Component label = super.newLabel(markupId, model);
         label.setRenderBodyOnly(false);
-        if (Strings.isEmpty(label.getDefaultModelObjectAsString())) {
-            label.add(AttributeModifier.append("class", "sr-only"));
-        }
         return label;
+    }
+    
+    @Override
+    protected void onConfigure() {
+    	super.onConfigure();
+    	Component label = get("label");
+        if (Strings.isEmpty(label.getDefaultModelObjectAsString())) {
+        	label.add(AttributeModifier.append("class", "sr-only"));
+        }
     }
 }

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxLink.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxLink.java
@@ -10,6 +10,7 @@ import org.apache.wicket.util.string.Strings;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.BootstrapAjaxLink;
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.Buttons;
+import de.agilecoders.wicket.core.util.CssClassNames.Helper;
 
 /**
  * A specialization of {@link de.agilecoders.wicket.core.markup.html.bootstrap.button.BootstrapAjaxLink}
@@ -102,7 +103,7 @@ public abstract class SpinnerAjaxLink<T> extends BootstrapAjaxLink<T> {
     	super.onConfigure();
     	Component label = get("label");
         if (Strings.isEmpty(label.getDefaultModelObjectAsString())) {
-        	label.add(AttributeModifier.append("class", "sr-only"));
+        	label.add(AttributeModifier.append("class", Helper.screenReaderOnly));
         }
     }
 }

--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxLink.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/spinner/SpinnerAjaxLink.java
@@ -103,7 +103,7 @@ public abstract class SpinnerAjaxLink<T> extends BootstrapAjaxLink<T> {
     	super.onConfigure();
     	Component label = get("label");
         if (Strings.isEmpty(label.getDefaultModelObjectAsString())) {
-        	label.add(AttributeModifier.append("class", Helper.screenReaderOnly));
+        	label.add(AttributeModifier.append("class", Helper.visuallyHidden));
         }
     }
 }

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/BasePage.html
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/BasePage.html
@@ -13,7 +13,7 @@
 
     <body style="padding-top: 60px">
         <a name="top" style="display: none;"></a>
-        <a class="sr-only" href="#content">Skip navigation</a>
+        <a class="visually-hidden" href="#content">Skip navigation</a>
 
         <header wicket:id="navbar" class="bs-docs-nav"></header>
 

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.html
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/ComponentsPage.html
@@ -1538,14 +1538,14 @@ Need to stack them on some viewports but not others? Use the responsive versions
         <div class="mb-2 p-2">
             <a href="#" wicket:id="button-with-badge">
                 Submit <span wicket:id="badge"></span>
-                <span class="sr-only">unread messages</span>
+                <span class="visually-hidden">unread messages</span>
             </a>
         </div>
 
         <pre class="prettyprint linenum">
             &lt;button wicket:id="badge-button"&gt;
                 Submit &lt;span wicket:id="button-count"&gt;&lt;/span&gt;
-                &lt;span class="sr-only"&gt;unread messages&lt;/span&gt;
+                &lt;span class="visually-hidden"&gt;unread messages&lt;/span&gt;
             &lt;/button&gt;
         </pre>
     </div>

--- a/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/SelectPage.html
+++ b/bootstrap-samples/src/main/java/de/agilecoders/wicket/samples/pages/SelectPage.html
@@ -82,7 +82,7 @@
                                     <div class="modal-header">
                                         <h4 class="modal-title" id="myModalLabel">Modal title</h4>
                                         <button type="button" class="btn-close" data-bs-dismiss="modal">
-                                            <span class="sr-only">Close</span>
+                                            <span class="visually-hidden">Close</span>
                                         </button>
                                     </div>
                                     <div class="modal-body">


### PR DESCRIPTION
In current implementation, just calling `setLabel()` triggers `AttributeModifier` that adds `.sr-only` even though the label's model may not be empty and in some setups label is not rendered because `.sr-only` class hides it. 

With this change, the check is made in `onConfigure`, but not very nice `get("label")` call is used - better way would require `BootstrapAjaxLink` and `BootstrapAjaxButton` methods that return label to be `protected` instead of `private`. Or extracting label's id to the constant and making protected that.