### PR TITLE
Revert typeahead to 0.10.x version, v0.11.x throws exception when using remote Bloodhound

### DIFF
--- a/bootstrap-extensions/pom.xml
+++ b/bootstrap-extensions/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <inputmask.version>5.0.6</inputmask.version>
         <jqueryui.version>1.13.2</jqueryui.version>
-        <typeaheadjs.version>0.11.1</typeaheadjs.version>
+        <typeaheadjs.version>0.10.5-1</typeaheadjs.version>
         <x-editable.version>1.5.1-1</x-editable.version>
         <spin-js.version>2.1.0</spin-js.version>
         <animate.css.version>3.7.2</animate.css.version>


### PR DESCRIPTION
Exception:
java.lang.IllegalArgumentException: Not valid encoding '%QU'

v0.11.x must have changed a way how url is constructed, didn't have time to align java components with this new version, so for now reverting webjar to the version that works