### PR TITLE
Add guava as dependency

### DIFF
--- a/bootstrap-extensions/pom.xml
+++ b/bootstrap-extensions/pom.xml
@@ -26,6 +26,7 @@
         <bootstrap-select.version>1.14.0-beta3</bootstrap-select.version>
         <tempusdominus4.version>5.39.0</tempusdominus4.version>
         <tempusdominus.version>6.7.11</tempusdominus.version>
+        <guava.version>32.1.3-jre</guava.version>
     </properties>
 
     <dependencies>
@@ -142,6 +143,12 @@
                     <artifactId>bootstrap</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Guava is missing but needed. It got unnoticed because it was delivered as transitive dependency of optional dependency in bootstrap-extensions

See #1024