### PR TITLE
chore: prevent dependabot from bumping font-awesome versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 50
+    ignore:
+        - dependency-name: "font-awesome"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot can bump the version number of font-awesome updates but we should not do that. A typical update will require changes in the following files:

![image](https://github.com/martin-g/wicket-bootstrap/assets/357238/901f17ed-c425-4387-ac33-4fd5d23f80bc)

And the same for the FontAwesom6 classes.

This PR prevents dependabot from bumping font-awesome completely. Updates will have to tracked and implemented manually.
