### PR TITLE
chore: Run CI tests on wicket-* branches

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,6 +4,7 @@ on:
     push:
       branches:
         - master
+        - 'wicket-*'
     pull_request:
       branches:
         - master

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,6 +7,7 @@ on:
     pull_request:
       branches:
         - master
+        - 'wicket-*'
 
 jobs:
   build:


### PR DESCRIPTION
IMHO it would be helpful to automaticially trigger builds and therefore runng tests for PRs that attempt to merge into one of the "wicket-*" branches. Also,, merge commits on those wicket-branches should trigger a build.

Personally, I would even activate the "Require status checks to pass before merging" rule in a branch protection rule for the most active branches.