### PR TITLE
Bootstrap5 RadioGroup layout fix

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BooleanRadioChoiceRenderer.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BooleanRadioChoiceRenderer.java
@@ -28,7 +28,7 @@ public class BooleanRadioChoiceRenderer extends DefaultRadioChoiceRenderer<Boole
         this.resourceSource = resourceSource;
     }
 
-    public IModel<String> lableOf(Boolean option) {
+    public IModel<String> labelOf(Boolean option) {
         return Model.of(getDisplayValue(option).toString());
     }
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.html
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.html
@@ -4,11 +4,12 @@
     </head>
     <body>
         <wicket:panel>
-        	<div wicket:id="radioGroup" class="btn-group btn-group-toggle" data-bs-toggle="buttons">
-			  <label wicket:id="radios" class="btn">
-			    <input wicket:id="radio" type="radio"><span wicket:id="label"></span>
-			  </label>
-			</div>  
+          <div wicket:id="radioGroup" class="btn-group" role="group">
+             <span wicket:id="items">
+                <input wicket:id="radio" type="radio" class="btn-check" name="btnradio"/>	  
+                <label wicket:id="label" class="btn btn-outline-primary"/>
+             </span>
+          </div>  
         </wicket:panel>
     </body>
 </html>

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.html
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.html
@@ -5,10 +5,10 @@
     <body>
         <wicket:panel>
           <div wicket:id="radioGroup" class="btn-group" role="group">
-             <span wicket:id="items">
+             <wicket:container wicket:id="radios">
                 <input wicket:id="radio" type="radio" class="btn-check" name="btnradio"/>	  
                 <label wicket:id="label" class="btn btn-outline-primary"/>
-             </span>
+             </wicket:container>
           </div>  
         </wicket:panel>
     </body>

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.java
@@ -117,18 +117,16 @@ public class BootstrapRadioGroup<T extends Serializable> extends GenericPanel<T>
                 }
             });
         }
-        RepeatingView radios = new RepeatingView("items");
+        RepeatingView radios = new RepeatingView("radios");
         radioGroup.add(radios);
         for (final IModel<T> model : options) {
            WebMarkupContainer wm = new WebMarkupContainer(radios.newChildId());
 
            Radio<T> radio = newRadio("radio", model, radioGroup);
            wm.add(radio);
-           Label label = new Label("label", choiceRenderer.lableOf(model.getObject()));
+           Label label = new Label("label", choiceRenderer.labelOf(model.getObject()));
            label.add(new AttributeAppender("for", radio.getMarkupId()));
            wm.add(label);
-
-           radios.add(wm.setRenderBodyOnly(true));
       }
     }
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.java
@@ -8,7 +8,6 @@ import de.agilecoders.wicket.jquery.util.Strings2;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
-import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -117,25 +116,19 @@ public class BootstrapRadioGroup<T extends Serializable> extends GenericPanel<T>
                 }
             });
         }
-        RepeatingView radios = new RepeatingView("radios");
+        RepeatingView radios = new RepeatingView("items");
         radioGroup.add(radios);
-        for (final IModel<T> model: options) {
-            WebMarkupContainer wm = new WebMarkupContainer(radios.newChildId()) {
-                private static final long serialVersionUID = 1L;
+        for (final IModel<T> model : options) {
+           WebMarkupContainer wm = new WebMarkupContainer(radios.newChildId());
 
-                @Override
-                protected void onComponentTag(ComponentTag tag) {
-                    super.onComponentTag(tag);
-                    // TODO: use model comparator?
-                    boolean active = model.getObject().equals(BootstrapRadioGroup.this.getModel().getObject());
-                    tag.put("class", "btn "+ choiceRenderer.getButtonClass(model.getObject())+ (active ? " active" : ""));
-                }
-            };
-            radios.add(wm);
-            Radio<T> radio = newRadio("radio", model, radioGroup);
-            wm.add(radio);
-            wm.add(new Label("label", choiceRenderer.lableOf(model.getObject())).setRenderBodyOnly(true));
-        }
+           Radio<T> radio = newRadio("radio", model, radioGroup);
+           wm.add(radio);
+           Label label = new Label("label", choiceRenderer.lableOf(model.getObject()));
+           label.add(new AttributeAppender("for", radio.getMarkupId()));
+           wm.add(label);
+
+           radios.add(wm.setRenderBodyOnly(true));
+      }
     }
 
     @Override

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/BootstrapRadioGroup.java
@@ -8,6 +8,7 @@ import de.agilecoders.wicket.jquery.util.Strings2;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/DefaultRadioChoiceRenderer.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/DefaultRadioChoiceRenderer.java
@@ -30,7 +30,7 @@ public class DefaultRadioChoiceRenderer<T extends Serializable> implements IRadi
     }
 
     @Override
-    public IModel<String> lableOf(T option) {
+    public IModel<String> labelOf(T option) {
         String label = option != null ? option.toString() : "";
         if (propertyLabel != null) {
             Object value = PropertyResolver.getValue(propertyLabel, option);

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/EnumRadioChoiceRenderer.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/EnumRadioChoiceRenderer.java
@@ -31,7 +31,7 @@ public class EnumRadioChoiceRenderer<T extends Enum<T>> extends DefaultRadioChoi
     }
 
 
-    public IModel<String> lableOf(T option) {
+    public IModel<String> labelOf(T option) {
         return Model.of(getDisplayValue(option).toString());
     }
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/IRadioChoiceRenderer.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/IRadioChoiceRenderer.java
@@ -16,7 +16,9 @@ public interface IRadioChoiceRenderer<T> extends IDetachable {
      * @deprecated Please use {@link #labelOf(Object)}
      */
     @Deprecated(forRemoval = true)
-    IModel<String> lableOf(T option);
+    default IModel<String> lableOf(T option) {
+        return null;
+    }
 
     default IModel<String> labelOf(T option) {
         return lableOf(option);

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/IRadioChoiceRenderer.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/IRadioChoiceRenderer.java
@@ -16,11 +16,11 @@ public interface IRadioChoiceRenderer<T> extends IDetachable {
      * @deprecated Please use {@link #labelOf(Object)}
      */
     @Deprecated(forRemoval = true)
-    default IModel<String> lableOf(T option) {
-        return labelOf(option);
-    };
+    IModel<String> lableOf(T option);
 
-    IModel<String> labelOf(T option);
+    default IModel<String> labelOf(T option) {
+        return lableOf(option);
+    };
 
     String getButtonClass(T option);
 }

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/IRadioChoiceRenderer.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/form/radio/IRadioChoiceRenderer.java
@@ -12,7 +12,15 @@ public interface IRadioChoiceRenderer<T> extends IDetachable {
 
     IModel<T> modelOf(T option);
 
-    IModel<String> lableOf(T option);
+    /**
+     * @deprecated Please use {@link #labelOf(Object)}
+     */
+    @Deprecated(forRemoval = true)
+    default IModel<String> lableOf(T option) {
+        return labelOf(option);
+    };
+
+    IModel<String> labelOf(T option);
 
     String getButtonClass(T option);
 }


### PR DESCRIPTION
Following bootstrap 5 radio layout (https://getbootstrap.com/docs/5.3/forms/checks-radios/#radios). Radios need the label to be a sibling with a "for" id attribute.

This is tested with bootswatch theme.