### PR TITLE
Add missing caret to BootstrapSelectFilter by changing the css class

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapSelectFilter.html
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/table/filter/BootstrapSelectFilter.html
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<wicket:panel xmlns:wicket="http://wicket.apache.org"><select wicket:id="filter" class="form-control"></select></wicket:panel>
+<wicket:panel xmlns:wicket="http://wicket.apache.org"><select wicket:id="filter" class="form-select"></select></wicket:panel>


### PR DESCRIPTION
When using the BootstrapSelectFilter the caret of the dropdown was not shown.
Changing the css class from "form-control" to "form-select" solves this issue (See: https://getbootstrap.com/docs/5.3/forms/select/).