### PR TITLE
Adds SassResourceUrlSanitizer to recognize variants in the URL

### DIFF
--- a/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/BootstrapSass.java
+++ b/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/BootstrapSass.java
@@ -4,6 +4,7 @@ import org.apache.wicket.Application;
 import org.apache.wicket.markup.html.IPackageResourceGuard;
 import org.apache.wicket.markup.html.SecurePackageResourceGuard;
 import org.apache.wicket.request.resource.IResourceReferenceFactory;
+import org.apache.wicket.request.resource.IResourceUrlSanitizer;
 import org.apache.wicket.request.resource.ResourceReferenceRegistry;
 
 /**
@@ -39,6 +40,10 @@ public final class BootstrapSass {
         ResourceReferenceRegistry resourceReferenceRegistry = app.getResourceReferenceRegistry();
         IResourceReferenceFactory delegate = resourceReferenceRegistry.getResourceReferenceFactory();
         resourceReferenceRegistry.setResourceReferenceFactory(new SassResourceReferenceFactory(delegate));
+
+        IResourceUrlSanitizer sanitizer = app.getResourceSettings().getUrlSanitizer();
+        SassResourceUrlSanitizer sassSanitizer = new SassResourceUrlSanitizer(sanitizer);
+        app.getResourceSettings().setUrlSanitizer(sassSanitizer);
     }
 
     /**

--- a/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/SassResourceUrlSanitizer.java
+++ b/bootstrap-sass/src/main/java/de/agilecoders/wicket/sass/SassResourceUrlSanitizer.java
@@ -1,0 +1,30 @@
+package de.agilecoders.wicket.sass;
+
+import org.apache.wicket.request.resource.IResourceUrlSanitizer;
+import org.apache.wicket.request.resource.ResourceReference;
+
+public class SassResourceUrlSanitizer implements IResourceUrlSanitizer
+{
+
+    private IResourceUrlSanitizer delegate;
+
+    public SassResourceUrlSanitizer(IResourceUrlSanitizer delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ResourceReference.UrlAttributes sanitize(ResourceReference.UrlAttributes urlAttributes,
+        Class<?> scope, String name)
+    {
+        if (ContextRelativeSassResourceReference.CONTEXT_RELATIVE_SASS_REFERENCE_VARIATION.equals(
+            urlAttributes.getVariation()))
+        {
+            return urlAttributes;
+        }
+        else
+        {
+            return delegate.sanitize(urlAttributes, scope, name);
+        }
+    }
+}


### PR DESCRIPTION
Should work in the next Wicket 10.x version and fix the disable test in BootstrapSassTest