### PR TITLE
Fix: Ensure JQuery is loaded before bootstrap-select

### DIFF
--- a/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/select/SelectJSReference.java
+++ b/bootstrap-extensions/src/main/java/de/agilecoders/wicket/extensions/markup/html/bootstrap/form/select/SelectJSReference.java
@@ -1,5 +1,12 @@
 package de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.wicket.Application;
+import org.apache.wicket.markup.head.HeaderItem;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+
 import de.agilecoders.wicket.webjars.request.resource.WebjarsJavaScriptResourceReference;
 
 /**
@@ -27,5 +34,15 @@ public class SelectJSReference extends WebjarsJavaScriptResourceReference {
      */
     private SelectJSReference() {
         super("bootstrap-select/current/dist/js/bootstrap-select.min.js");
+    }
+
+
+    @Override
+    public List<HeaderItem> getDependencies() {
+        
+        return Collections.singletonList(
+            JavaScriptHeaderItem.forReference(Application.get().getJavaScriptLibrarySettings().getJQueryReference())
+        );
+        
     }
 }


### PR DESCRIPTION
### Problem
When using BootstrapSelect, the bootstrap-select.min.js may be rendered before jQuery resulting in runtime errors:

```
bootstrap-select.js:355 Uncaught TypeError: Cannot read properties of undefined (reading 'valHooks')
    at bootstrap-select.js:355:13
    at bootstrap-select.js:1:1
    at bootstrap-select.min-ver-1748962077046.js:7:191
    at bootstrap-select.min-ver-1748962077046.js:7:203
(anonymous) @ bootstrap-select.js:355
(anonymous) @ bootstrap-select.js:1
(anonymous) @ bootstrap-select.min-ver-1748962077046.js:7
(anonymous) @ bootstrap-select.min-ver-1748962077046.js:7Understand this error
```
### Root Cause
SelectJSReference does not declare jQuery as a dependency.

Fixes #1231.