### PR TITLE
Close Modal Dialog with Escape Key

### DIFF
--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/Modal.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/Modal.java
@@ -292,6 +292,10 @@ public class Modal<T> extends GenericPanel<T> {
             Attributes.removeClass(tag, "fade");
         }
 
+        // To receive the escape key event the tabindex attribute is needed. If it is missing the browser will ignore
+        // the event because the div has no focus. tabindex=-1 makes the modal div programmatically focusable
+        // but excludes it from the sequential keyboard navigation.
+        Attributes.set(tag, "tabindex", "-1");
         Attributes.set(tag, "data-bs-keyboard", "" + closeOnEscapeKey);
         Attributes.set(tag, "data-bs-focus", "" + !disableEnforceFocus.getObject());
 

--- a/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/Modal.java
+++ b/bootstrap-core/src/main/java/de/agilecoders/wicket/core/markup/html/bootstrap/dialog/Modal.java
@@ -109,7 +109,6 @@ public class Modal<T> extends GenericPanel<T> {
 
     private boolean show = false;
     private boolean fadein = true;
-    private boolean keyboard = true;
     private boolean closeOnEscapeKey = true;
     private Backdrop backdrop = Backdrop.TRUE;
 
@@ -406,6 +405,13 @@ public class Modal<T> extends GenericPanel<T> {
     }
 
     /**
+     * @return true, if closing on <em>ESC</em> keyboard key is enabled or not
+     */
+    public boolean useCloseOnEscapeKey() {
+        return closeOnEscapeKey;
+    }
+
+    /**
      * Sets a flag that decides whether using the <em>ESC</em> keyboard
      * key will close this modal
      *
@@ -574,10 +580,13 @@ public class Modal<T> extends GenericPanel<T> {
     }
 
     /**
+     * @deprecated use {@link #useCloseOnEscapeKey()} instead
+     *
      * @return true, if keyboard usage is activated
      */
+    @Deprecated(since = "7.0.15", forRemoval = true)
     protected final boolean useKeyboard() {
-        return keyboard;
+        return closeOnEscapeKey;
     }
 
     /**
@@ -601,11 +610,14 @@ public class Modal<T> extends GenericPanel<T> {
     /**
      * Whether to enable keyboard interaction like ESC to close the dialog.
      *
+     * @deprecated use {@link #setCloseOnEscapeKey(boolean)} instead.
+     *
      * @param keyboard true, if keyboard interaction is enabled
      * @return This
      */
+    @Deprecated(since = "7.0.15", forRemoval = true)
     public final Modal<T> setUseKeyboard(boolean keyboard) {
-        this.keyboard = keyboard;
+        this.closeOnEscapeKey = keyboard;
         return this;
     }
 


### PR DESCRIPTION
Hi martin-g,

I discovered that the Modal does not close when pressing the "Escape "key because the browser ignores the event for the modal div. This is because the attribute "tabindex=-1" is missing.

As I have learned now, this attribute enables the modal div to have the keyboard focus set on it, because not all html components have this ability by default like <input>, ....

Independently of this fix I recognized, that the "keyboard" variable of de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal has no effect because it is used nowhere and the "closeOnEscapeKey"-Variable does the job instead and initializes the bootstrap modal.js "keyboard" variable.

Attributes.set(tag, "data-bs-keyboard", "" + closeOnEscapeKey);

What to do? Should I delete the "keyboard" variable and its corresponding methods?

* de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal#useKeyboard
* de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal#setUseKeyboard

If I do this it could break the compilation of projects that use this methods. Can you tell me what is the best way to deal with this variable?


Greetings Namtar